### PR TITLE
Update SBEMimage_DMcom_GMS3.s

### DIFF
--- a/dm/SBEMimage_DMcom_GMS3.s
+++ b/dm/SBEMimage_DMcom_GMS3.s
@@ -63,7 +63,7 @@ number idle_counter
 number idle_threshold
 number start_time, start_time2
 number cycle_start_time
-number time_elapsed, time_elapsed2
+number time_elapsed, time_elapsed2, timeElapsed, timeElapsed2
 number success
 number remote_control
 number stroke_down
@@ -632,7 +632,7 @@ void wait_for_command()
 			start_time = GetCurrentTime()
 			EMSetStageX(0)
 			EMSetStageY(0)
-			while ((abs(EMGetStageX()) > 0.010) or (abs(EMGetStageY()) > 0.010)) {
+			while ((abs(EMGetStageX()) > 0.010) || (abs(EMGetStageY()) > 0.010)) {
 				sleep(1)
 				timeElapsed = (GetCurrentTime() - start_time) / 10000000
 				if (timeElapsed > 30) {


### PR DESCRIPTION
I was trying to execute SBEMimage_DMcom_GMS3.s in DigitalMicrograph and received errrors at line 635 about expecting ')'. The parentheses looked fine, but I noticed the or in the while statement didn't match the || in other conditional statements in the code. After I changed that, timeElapsed and timeElapsed2 where not declared (time_elapsed and time_elapsed2 are), so I declared them.