### PR TITLE
Z Depth Target

### DIFF
--- a/gui/acq_settings_dlg.ui
+++ b/gui/acq_settings_dlg.ui
@@ -119,7 +119,7 @@
     <string>Slice thickness in nanometres:</string>
    </property>
   </widget>
-  <widget class="QSpinBox" name="spinBox_targetNumberSlices">
+  <widget class="QSpinBox" name="spinBox_numberSlices">
    <property name="geometry">
     <rect>
      <x>220</x>
@@ -328,7 +328,7 @@
     <string>Set ∆Z (depth already cut, in μm):</string>
    </property>
   </widget>
-  <widget class="QDoubleSpinBox" name="doubleSpinBox_zDiff">
+  <widget class="QDoubleSpinBox" name="doubleSpinBox_totalZDiff">
    <property name="geometry">
     <rect>
      <x>220</x>
@@ -402,7 +402,7 @@
     </property>
    </item>
   </widget>
-  <widget class="QDoubleSpinBox" name="doubleSpinBox_targetZDepth">
+  <widget class="QDoubleSpinBox" name="doubleSpinBox_targetZDiff">
    <property name="geometry">
     <rect>
      <x>220</x>
@@ -421,7 +421,7 @@
     <double>0.000000000000000</double>
    </property>
   </widget>
-  <zorder>doubleSpinBox_targetZDepth</zorder>
+  <zorder>doubleSpinBox_targetZDiff</zorder>
   <zorder>buttonBox</zorder>
   <zorder>label_csn</zorder>
   <zorder>label_bd</zorder>
@@ -429,7 +429,7 @@
   <zorder>pushButton_selectDir</zorder>
   <zorder>line_1</zorder>
   <zorder>label_st</zorder>
-  <zorder>spinBox_targetNumberSlices</zorder>
+  <zorder>spinBox_numberSlices</zorder>
   <zorder>spinBox_sliceCounter</zorder>
   <zorder>spinBox_sliceThickness</zorder>
   <zorder>label_expl0</zorder>
@@ -443,7 +443,7 @@
   <zorder>lineEdit_adminEmail</zorder>
   <zorder>label_3</zorder>
   <zorder>label_csn_2</zorder>
-  <zorder>doubleSpinBox_zDiff</zorder>
+  <zorder>doubleSpinBox_totalZDiff</zorder>
   <zorder>label_st_2</zorder>
   <zorder>label_stackName</zorder>
   <zorder>comboBox_targetType</zorder>
@@ -452,9 +452,9 @@
   <tabstop>lineEdit_baseDir</tabstop>
   <tabstop>pushButton_selectDir</tabstop>
   <tabstop>spinBox_sliceThickness</tabstop>
-  <tabstop>spinBox_targetNumberSlices</tabstop>
+  <tabstop>spinBox_numberSlices</tabstop>
   <tabstop>spinBox_sliceCounter</tabstop>
-  <tabstop>doubleSpinBox_zDiff</tabstop>
+  <tabstop>doubleSpinBox_totalZDiff</tabstop>
   <tabstop>checkBox_EHTOff</tabstop>
   <tabstop>checkBox_sendMetaData</tabstop>
   <tabstop>lineEdit_metaDataServer</tabstop>

--- a/gui/acq_settings_dlg.ui
+++ b/gui/acq_settings_dlg.ui
@@ -106,19 +106,6 @@
     <enum>Qt::Horizontal</enum>
    </property>
   </widget>
-  <widget class="QLabel" name="label_sn">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>120</y>
-     <width>161</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Target number of slices:</string>
-   </property>
-  </widget>
   <widget class="QLabel" name="label_st">
    <property name="geometry">
     <rect>
@@ -132,7 +119,7 @@
     <string>Slice thickness in nanometres:</string>
    </property>
   </widget>
-  <widget class="QSpinBox" name="spinBox_numberSlices">
+  <widget class="QSpinBox" name="spinBox_targetNumberSlices">
    <property name="geometry">
     <rect>
      <x>220</x>
@@ -392,15 +379,57 @@
     <string>MyStackName</string>
    </property>
   </widget>
+  <widget class="QComboBox" name="comboBox_targetType">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>120</y>
+     <width>141</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="layoutDirection">
+    <enum>Qt::LeftToRight</enum>
+   </property>
+   <item>
+    <property name="text">
+     <string>Target number of slices:</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Target depth (μm):</string>
+    </property>
+   </item>
+  </widget>
+  <widget class="QDoubleSpinBox" name="doubleSpinBox_targetZDepth">
+   <property name="geometry">
+    <rect>
+     <x>220</x>
+     <y>120</y>
+     <width>71</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="decimals">
+    <number>3</number>
+   </property>
+   <property name="maximum">
+    <double>999.999000000000024</double>
+   </property>
+   <property name="value">
+    <double>0.000000000000000</double>
+   </property>
+  </widget>
+  <zorder>doubleSpinBox_targetZDepth</zorder>
   <zorder>buttonBox</zorder>
   <zorder>label_csn</zorder>
   <zorder>label_bd</zorder>
   <zorder>lineEdit_baseDir</zorder>
   <zorder>pushButton_selectDir</zorder>
   <zorder>line_1</zorder>
-  <zorder>label_sn</zorder>
   <zorder>label_st</zorder>
-  <zorder>spinBox_numberSlices</zorder>
+  <zorder>spinBox_targetNumberSlices</zorder>
   <zorder>spinBox_sliceCounter</zorder>
   <zorder>spinBox_sliceThickness</zorder>
   <zorder>label_expl0</zorder>
@@ -417,12 +446,13 @@
   <zorder>doubleSpinBox_zDiff</zorder>
   <zorder>label_st_2</zorder>
   <zorder>label_stackName</zorder>
+  <zorder>comboBox_targetType</zorder>
  </widget>
  <tabstops>
   <tabstop>lineEdit_baseDir</tabstop>
   <tabstop>pushButton_selectDir</tabstop>
   <tabstop>spinBox_sliceThickness</tabstop>
-  <tabstop>spinBox_numberSlices</tabstop>
+  <tabstop>spinBox_targetNumberSlices</tabstop>
   <tabstop>spinBox_sliceCounter</tabstop>
   <tabstop>doubleSpinBox_zDiff</tabstop>
   <tabstop>checkBox_EHTOff</tabstop>

--- a/gui/main_window.ui
+++ b/gui/main_window.ui
@@ -366,7 +366,7 @@
           <string>RESET</string>
          </property>
         </widget>
-        <widget class="QLabel" name="label_ns">
+        <widget class="QLabel" name="label_t">
          <property name="geometry">
           <rect>
            <x>10</x>
@@ -616,12 +616,12 @@
           <string>...</string>
          </property>
         </widget>
-        <widget class="QLabel" name="label_4">
+        <widget class="QLabel" name="label_cp">
          <property name="geometry">
           <rect>
            <x>360</x>
            <y>200</y>
-           <width>71</width>
+           <width>91</width>
            <height>16</height>
           </rect>
          </property>
@@ -629,7 +629,7 @@
           <string>Current slice:</string>
          </property>
         </widget>
-        <widget class="QLabel" name="label_sliceCounter">
+        <widget class="QLabel" name="label_currentPosition">
          <property name="geometry">
           <rect>
            <x>470</x>
@@ -835,7 +835,7 @@
           <string/>
          </property>
         </widget>
-        <widget class="QLabel" name="label_numberSlices">
+        <widget class="QLabel" name="label_target">
          <property name="geometry">
           <rect>
            <x>132</x>

--- a/src/acquisition.py
+++ b/src/acquisition.py
@@ -933,7 +933,7 @@ class Acquisition:
 
             if self.use_target_z_diff:
                 # stop when cutting another slice at the current thickness would exceed the target z depth
-                if (self.total_z_diff + self.slice_thickness) > self.target_z_diff:
+                if (self.total_z_diff + (self.slice_thickness/1000)) > self.target_z_diff:
                     self.stack_completed = True
             else:
                 if self.slice_counter == self.number_slices:

--- a/src/config_template.py
+++ b/src/config_template.py
@@ -23,7 +23,7 @@ from configparser import ConfigParser
 # deleted from the default configuration files
 CFG_TEMPLATE_FILE = '..\\src\\default_cfg\\default.ini'    # Template of session configuration
 CFG_NUMBER_SECTIONS = 12
-CFG_NUMBER_KEYS = 214
+CFG_NUMBER_KEYS = 216
 
 SYSCFG_TEMPLATE_FILE = '..\\src\\default_cfg\\system.cfg'  # Template of system configuration
 SYSCFG_NUMBER_SECTIONS = 8

--- a/src/default_cfg/default.ini
+++ b/src/default_cfg/default.ini
@@ -162,6 +162,10 @@ number_slices = 1000
 slice_counter = 0
 # cutting thickness in nanometres; acquisition
 slice_thickness = 50
+# whether to use a target z diff (true), or a target number of slices (false); acquisition
+use_target_z_diff = False
+# target Z depth to be acquired, in micrometres; acquisition
+target_z_diff = 0.0
 # total Z depth of sample removed by microtome since last reset, in micrometres; acquisition
 total_z_diff = 0.0
 # True if acquisition paused; acquisition

--- a/src/main_controls.py
+++ b/src/main_controls.py
@@ -880,7 +880,7 @@ class MainControls(QMainWindow):
             f'{total_stage_moves/total_duration * 100:.1f}% / '
             f'{total_cutting/total_duration * 100:.1f}%)')
         self.label_totalArea.setText('{0:.1f}'.format(total_area) + ' µm²')
-        self.label_totalZ.setText('{0:.1f}'.format(total_z) + ' µm')
+        self.label_totalZ.setText('{0:.2f}'.format(total_z) + ' µm')
         self.label_totalData.setText('{0:.1f}'.format(total_data) + ' GB')
         days, hours, minutes = utils.get_days_hours_minutes(remaining_time)
         self.label_dateEstimate.setText(

--- a/src/main_controls.py
+++ b/src/main_controls.py
@@ -848,7 +848,12 @@ class MainControls(QMainWindow):
             str(self.gm[self.grid_index_dropdown].number_active_tiles()))
         # Acquisition parameters
         self.lineEdit_baseDir.setText(self.acq.base_dir)
-        self.label_numberSlices.setText(str(self.acq.number_slices))
+        if self.acq.use_target_z_diff:
+            self.label_t.setText("Target Z depth (μm):")
+            self.label_target.setText(str(self.acq.target_z_diff))
+        else:
+            self.label_t.setText("Target number of slices:")
+            self.label_target.setText(str(self.acq.number_slices))
         if self.use_microtome:
             self.label_sliceThickness.setText(
                 str(self.acq.slice_thickness) + ' nm')
@@ -1684,15 +1689,26 @@ class MainControls(QMainWindow):
 
     def show_stack_progress(self):
         current_slice = self.acq.slice_counter
-        if self.acq.number_slices > 0:
-            self.label_sliceCounter.setText(
-                str(current_slice) + '      (' + chr(8710) + 'Z = '
-                + '{0:.3f}'.format(self.acq.total_z_diff) + ' µm)')
+        total_z_diff = self.acq.total_z_diff
+
+        if self.acq.use_target_z_diff:
+            self.label_cp.setText("Current Z depth:")
+            self.label_currentPosition.setText(
+                '{0:.3f}'.format(total_z_diff) + ' µm' + '      (slice no. = '
+                + str(current_slice) + ")")
             self.progressBar.setValue(
-                current_slice / self.acq.number_slices * 100)
+                total_z_diff / self.acq.target_z_diff * 100)
         else:
-            self.label_sliceCounter.setText(
-                str(current_slice) + "      (no cut after acq.)")
+            self.label_cp.setText("Current slice:")
+            if self.acq.number_slices > 0:
+                self.label_currentPosition.setText(
+                    str(current_slice) + '      (' + chr(8710) + 'Z = '
+                    + '{0:.3f}'.format(self.acq.total_z_diff) + ' µm)')
+                self.progressBar.setValue(
+                    current_slice / self.acq.number_slices * 100)
+            else:
+                self.label_currentPosition.setText(
+                    str(current_slice) + "      (no cut after acq.)")
 
     def show_current_stage_xy(self):
         xy_pos = self.stage.last_known_xy
@@ -2454,7 +2470,7 @@ class MainControls(QMainWindow):
             self.pushButton_resetAcq.setEnabled(False)
             self.pushButton_pauseAcq.setEnabled(False)
             self.pushButton_startAcq.setEnabled(True)
-            self.label_sliceCounter.setText('---')
+            self.label_currentPosition.setText('---')
             self.progressBar.setValue(0)
             self.show_stack_acq_estimates()
             self.pushButton_startAcq.setText('START')

--- a/src/main_controls_dlg_windows.py
+++ b/src/main_controls_dlg_windows.py
@@ -1991,7 +1991,11 @@ class AcqSettingsDlg(QDialog):
         self.update_stack_name()
         self.new_base_dir = ''
         self.spinBox_sliceThickness.setValue(self.acq.slice_thickness)
-        self.spinBox_numberSlices.setValue(self.acq.number_slices)
+
+        self.comboBox_targetType.currentIndexChanged.connect(self.switch_target_spinbox)
+        self.spinBox_targetNumberSlices.setValue(self.acq.number_slices)
+        self.doubleSpinBox_targetZDepth.hide()
+
         self.spinBox_sliceCounter.setValue(self.acq.slice_counter)
         self.doubleSpinBox_zDiff.setValue(self.acq.total_z_diff)
         self.checkBox_sendMetaData.setChecked(self.acq.send_metadata)
@@ -2031,6 +2035,15 @@ class AcqSettingsDlg(QDialog):
     def update_stack_name(self):
         base_dir = self.lineEdit_baseDir.text().rstrip(r'\/ ')
         self.label_stackName.setText(base_dir[base_dir.rfind('\\') + 1:])
+
+    def switch_target_spinbox(self):
+        """ When target number of slices is used, a QSpinbox with integer steps is used.
+        When target depth is used, a QDoubleSpinbox with fractional steps is used.
+        """
+        slice_spin_box = self.spinBox_targetNumberSlices
+        depth_spin_box = self.doubleSpinBox_targetZDepth
+        slice_spin_box.setVisible(not slice_spin_box.isVisible())
+        depth_spin_box.setVisible(not depth_spin_box.isVisible())
 
     def accept(self):
         success = True


### PR DESCRIPTION
Adds the option for a z depth target (in microns), rather than only a target number of slices.

Main changes:
- Added a dropdown to the acquisition settings to choose depth or slice target (this toggles the visibility of the relevant spinbox)
- Added 'target_z_diff' and 'use_target_z_diff' to the configuration files
- Made label swap between displaying 'target number of slices' and 'target z depth' in the acquisition panel
- Made progress bar swap between showing progress based on slice number & progress based on depth
- Update acquisition estimates to use the nearest whole number of slices, given the target z depth (when z depth target active)
- Acquisition loop swaps between checking current slice is equal to target slice, and checking the current total_z_depth + slice thickness is not larger than the target_z_depth


closes https://github.com/SBEMimage/SBEMimage/issues/71

