### PR TITLE
katana-related updates

### DIFF
--- a/src/acquisition.py
+++ b/src/acquisition.py
@@ -1165,6 +1165,7 @@ class Acquisition:
                                  + str(self.slice_thickness)
                                  + ' nm cutting thickness).')
             # Do the full cut cycle (near, cut, retract, clear)
+            print('ssearle debug - do full cut')
             self.microtome.do_full_cut()
             # Process tiles for heuristic autofocus during cut
             if self.heuristic_af_queue:
@@ -1192,6 +1193,7 @@ class Acquisition:
                     self.add_to_main_log(
                         'GCIB: Omitting post-cut sleep.')
             cut_cycle_delay = self.microtome.check_cut_cycle_status()
+            print('ssearle debug - cut_cycle_delay = ' + str(cut_cycle_delay))
             if cut_cycle_delay is not None and cut_cycle_delay > 0:
                 utils.log_error(
                     'KNIFE',


### PR DESCRIPTION
If the user makes the entire cut movement slow (not just the cutting window), then the whole cut can easily take more than a minute.
SBEMimage will currently only wait 15s beyond the expected cut time (specified in the calibration menu) for the cut to finish, at which point the imaging will continue regardless. I have now extended this from 15s to 240s to cover the slowest of cuts.

In the worst case, if a comms problem causes a cut signal to be missed once during a long acquisition, then 240s will be wasted waiting before continuing.

Also added a few other debugging print lines. Can be removed at a later date