### PR TITLE
Tcp remote

### DIFF
--- a/src/acquisition.py
+++ b/src/acquisition.py
@@ -1123,7 +1123,7 @@ class Acquisition:
     def send_data_tcp(self):
         res = self.tcp_remote.send({
             'paused': self.pause_state != 0,
-            'z_depth': self.total_z_diff,
+            'z_depth': self.microtome.get_stage_z(),
             'overviews': {'number_ov': self.ovm.number_ov,
                           'ov_coords': self.get_ov_coords(),
                           'ov_dirs': self.get_ov_dirs()},

--- a/src/grid_manager.py
+++ b/src/grid_manager.py
@@ -872,7 +872,13 @@ class Grid(list):
         """Clear all preview images in this grid."""
         for tile in self:
             tile.preview_src = ''  # Setter will set preview_img to None
-
+            
+    def activate_tiles_from_mask(self, mask):
+        """Activate tiles based on a boolean mask."""
+        mask = mask.flatten()
+        if len(mask) != self.number_tiles:
+            raise ValueError('Mask length does not match number of tiles.')
+        self.active_tiles = np.where(mask)[0].tolist()
 
 class GridManager(list):
 
@@ -1450,7 +1456,7 @@ class GridManager(list):
                     grid.auto_update_tile_positions = True
                     grid.centre_sx_sy = center
 
-    def add_new_grid_from_roi(self, array_index, roi_index, center, size, rotation):
+    def add_new_grid_from_roi(self, array_index, roi_index, center, size, rotation, mask=None):
         # use first matching roi grid as template
         template_index = self.find_grid_index(roi_index)
         if template_index is None:
@@ -1476,6 +1482,18 @@ class GridManager(list):
                                      wd_stig_xy=grid.wd_stig_xy, use_wd_gradient=grid.use_wd_gradient,
                                      wd_gradient_ref_tiles=grid.wd_gradient_ref_tiles,
                                      wd_gradient_params=grid.wd_gradient_params)
+        if mask is not None:
+            mask = np.asarray(mask, dtype=np.uint8)
+            # pad mask to match tile size
+            px_size_y = mask.shape[0] / h
+            px_size_x = mask.shape[0] / w
+            dh =  (tiles[0] * tile_height - h) / 2
+            dw = (tiles[1] * tile_width - w) / 2
+            mask = np.pad(mask, ((round(dh * px_size_y), round(dh * px_size_y)), 
+                          (round(dw * px_size_x), round(dw * px_size_x))))
+            # reshape mask to match tiles in grid
+            mask = utils.resize_image_max_pool(mask, (tiles[1], tiles[0]))
+            new_grid.activate_tiles_from_mask(mask)
 
         new_grid.array_index = array_index
         new_grid.roi_index = roi_index

--- a/src/tcp_remote.py
+++ b/src/tcp_remote.py
@@ -16,6 +16,16 @@ class TCPRemote:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.connect((self.host, self.port))
             s.sendall(json.dumps(msg).encode('utf-8'))
-            response = json.loads((s.recv(1024)))
+            # response = json.loads((s.recv(1024)))
+            response_data = b""
+            while True:
+                chunk = s.recv(1024)
+                if not chunk:
+                    break  # connection closed by server
+                response_data += chunk
+                # Check if we've reached the end of the message (if newline is the delimiter)
+                if b'\n' in chunk:  
+                    break  # Stop reading when a newline is found
+            response = json.loads(response_data)
             return response
         

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,6 +29,7 @@ from skimage.measure import ransac
 from serial.tools import list_ports
 from qtpy.QtCore import QObject, Signal, QSize
 from qtpy.QtGui import QIcon, QPixmap, QImage, QTransform
+from scipy.ndimage import maximum_filter
 
 from constants import *
 
@@ -608,6 +609,16 @@ def resize_image(image, new_size):
         size = np.flip(image.shape[:2])
         new_size = new_size, new_size * size[1] // size[0]
     return cv2.resize(image, new_size)
+
+
+def resize_image_max_pool(image, new_size):
+    if not isinstance(new_size, (tuple, list, np.ndarray)):
+        # use single value for width; apply aspect ratio
+        size = np.flip(image.shape[:2])
+        new_size = new_size, new_size * size[1] // size[0]
+    height_factor = -(image.shape[0] // -new_size[1])
+    width_factor = -(image.shape[1] // -new_size[0])
+    return maximum_filter(image, size=(height_factor, width_factor))[::height_factor, ::width_factor]
 
 
 def transform_to_QTransform(transform0):


### PR DESCRIPTION
Added changes to the TCP remote feature to support recent changes in the napari SBEMViewer plugin.

Changes:
- the z coordinates from the microtome are sent via TCP to match how the image metadata records z height
- added a mask parameter to `GridManager.add_new_grid_from_roi` to allow adding irregularly shaped grids