### PR TITLE
Tcp remote

### DIFF
--- a/src/acquisition.py
+++ b/src/acquisition.py
@@ -1123,7 +1123,7 @@ class Acquisition:
     def send_data_tcp(self):
         res = self.tcp_remote.send({
             'paused': self.pause_state != 0,
-            'z_depth': self.microtome.get_stage_z(),
+            'z_depth': self.stage.get_z(),
             'overviews': {'number_ov': self.ovm.number_ov,
                           'ov_coords': self.get_ov_coords(),
                           'ov_dirs': self.get_ov_dirs()},

--- a/src/utils.py
+++ b/src/utils.py
@@ -616,8 +616,8 @@ def resize_image_max_pool(image, new_size):
         # use single value for width; apply aspect ratio
         size = np.flip(image.shape[:2])
         new_size = new_size, new_size * size[1] // size[0]
-    height_factor = -(image.shape[0] // -new_size[1])
-    width_factor = -(image.shape[1] // -new_size[0])
+    height_factor = int(np.ceil(image.shape[0] / new_size[1]))
+    width_factor = int(np.ceil(image.shape[1] / new_size[0]))
     return maximum_filter(image, size=(height_factor, width_factor))[::height_factor, ::width_factor]
 
 


### PR DESCRIPTION
Add small fixes for recent tcp-remote PR:

- use numpy for ceiling division
- get z depth info from `stage.get_z()` to handle cases where there is no microtome