### PR TITLE
Fix max pool image resize function

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -618,7 +618,8 @@ def resize_image_max_pool(image, new_size):
         new_size = new_size, new_size * size[1] // size[0]
     height_factor = int(np.ceil(image.shape[0] / new_size[1]))
     width_factor = int(np.ceil(image.shape[1] / new_size[0]))
-    return maximum_filter(image, size=(height_factor, width_factor))[::height_factor, ::width_factor]
+    max_filter = maximum_filter(image, size=(height_factor, width_factor))
+    return max_filter[height_factor//2::height_factor, width_factor//2::width_factor]
 
 
 def transform_to_QTransform(transform0):


### PR DESCRIPTION
Fixes issue where some tiles at grid boundaries do not activate.

The max pool resize function works by:
1. applying a max filter to the image
2. taking every nth pixel to obtain a new image of the target size

This fix takes the nth pixel starting from n/2 to avoid cases where the max filter returns 0 at boundaries.