### PR TITLE
convert rois to stage coordinates

### DIFF
--- a/src/acquisition.py
+++ b/src/acquisition.py
@@ -1152,7 +1152,7 @@ class Acquisition:
                 self.set_ov_interval(*args, **kwargs)
                 self.main_controls_trigger.transmit('SHOW CURRENT SETTINGS')
             elif msg == 'ADD ARRAY GRID':
-                self.gm.add_new_grid_from_roi(*args, **kwargs)
+                self.gm.add_new_grid_from_overview_roi(*args, **kwargs)
                 self.main_controls_trigger.transmit('DRAW VP')
             elif msg == 'DELETE ALL ARRAY GRIDS':
                 self.gm.delete_array_grids(*args, **kwargs)

--- a/src/grid_manager.py
+++ b/src/grid_manager.py
@@ -1424,7 +1424,19 @@ class GridManager(list):
             location = utils.apply_transform(landmark, transform)
             self.set_array_landmark(landmark_id, location, landmark_type='stage')
             self.set_array_landmark(landmark_id, location, landmark_type='target')
-
+            
+    def convert_overview_coords_to_stage(self, ov_position, roi_center):
+        # given the position of the overview in stage coordinates and the position of an roi relative
+        # to the centre of the overview, return the position of the roi in stage coordinates
+        roi_center_stage = self.cs.convert_d_to_s(roi_center)
+        transform = utils.create_transform(translate=ov_position)
+        return utils.apply_transform(roi_center_stage, transform)
+    
+    def add_new_grid_from_overview_roi(self, array_index, roi_index, roi_center, size, ov_position, mask=None):
+        # convert the roi_center to stage coordinates
+        roi_stage_coords = self.convert_overview_coords_to_stage(ov_position, roi_center)
+        self.add_new_grid_from_roi(array_index, roi_index, roi_stage_coords, size, 0, mask)
+        
     def array_create_grids(self, imported_image):
         sem_stage_flipped = self.cs.get_sem_stage_flipped()
         self.delete_array_grids(keep_template_grids=True)


### PR DESCRIPTION
Fix issue where stage is at a different angle to SEM.

changes:
- ADD ARRAY GRID tcp command expects roi coordinates to be relative to the centre of the overview and includes a new parameter for overview position relative to the stage
- calls new function `add_new_grid_from_overview_roi` which converts the coordinates to be relative to the stage. `self.cs.convert_d_to_s(roi_center)` is used here to deal with the rotation and scale factors when changing from SEM coordinates to stage coordinates, and the overview position is added as an offset