### PR TITLE
Fixed slice-by-slice viewer for ROI grids

### DIFF
--- a/src/Viewport.py
+++ b/src/Viewport.py
@@ -3341,7 +3341,7 @@ class Viewport(QWidget):
                 filename = os.path.join(
                     self.acq.base_dir, utils.tile_relative_save_path(
                         self.acq.stack_name, self.sv_current_grid,
-                        None, None,
+                        None, self.gm[self.sv_current_grid].roi_index,
                         self.sv_current_tile, start_slice - index))
             if filename and os.path.isfile(filename):
                 self.slice_view_images.append(utils.image_to_QPixmap(imread(filename)))

--- a/src/Viewport.py
+++ b/src/Viewport.py
@@ -3338,10 +3338,11 @@ class Viewport(QWidget):
                     self.acq.base_dir, self.acq.stack_name,
                     self.sv_current_ov, start_slice - index)
             elif self.sv_current_tile >= 0:
+                grid = self.gm[self.sv_current_grid]
                 filename = os.path.join(
                     self.acq.base_dir, utils.tile_relative_save_path(
                         self.acq.stack_name, self.sv_current_grid,
-                        None, self.gm[self.sv_current_grid].roi_index,
+                        grid.array_index, grid.roi_index,
                         self.sv_current_tile, start_slice - index))
             if filename and os.path.isfile(filename):
                 self.slice_view_images.append(utils.image_to_QPixmap(imread(filename)))

--- a/src/constants.py
+++ b/src/constants.py
@@ -19,7 +19,7 @@ import re
 # master branch (for example, '2020.07 R2020-07-28'). For the current version
 # in the dev (development) branch, it must contain the tag 'dev'.
 # Following https://www.python.org/dev/peps/pep-0440/#public-version-identifiers
-VERSION = '2025.3.10 dev'
+VERSION = '2025.3.11 dev'
 
 
 # Default and minimum size of the Viewport canvas.


### PR DESCRIPTION
Fix the issue where ROI grids aren't loaded correctly in the slice-by-slice.

Fix by passing `roi_index` into `utils.tile_relative_save_path` if it exists.