### PR TITLE
Add Automated Focus/Stigmator Series (AFSS) Autofunction

### DIFF
--- a/docs/autofocus_afss_help.md
+++ b/docs/autofocus_afss_help.md
@@ -1,0 +1,31 @@
+# Automated Focus/Stigmator Series (AFSS)
+
+AFSS optimizes focus and stigmation by applying small working distance or stigmator variations to tracked tiles across multiple cuts and analyzing resulting sharpness changes. It runs during acquisition without adding extra electron exposure. Starting focus/stigmation should be reasonably close to optimal.  
+
+---
+
+## How it works
+- Each series of type **Focus**, **StigX**, or **StigY** runs during several slices in the following sequence:  
+  *Autofocus → StigX → StigY → Autofocus …*  
+  Triggered by **Interval N slices**. Autofocus can run alone if *AutoStigmator* is disabled.  
+- Sharpness is measured using edge detection with a circular mask to exclude tile borders.  
+- WD/Stig variations vs. sharpness are fit with a parabolic or linear model to estimate the optimum.  
+- Resulting plots are saved in `/meta/stats` for optional inspection.  
+- Fits with high RMSE or failed convergence are excluded automatically.  
+
+---
+
+## Consensus modes
+- **Average mode** (default): applies averaged corrections across tiles.  
+- **Specific mode**: applies per-tile corrections, mainly for rough initial estimations.  
+- **Mixed mode**: e.g. *Specific: Focus, Average: Stig* for focus gradient corrections.  
+
+---
+
+## Practical notes
+- **Number of WD/Stig variations:** three are sufficient; increase if reliability issues occur.  
+- **Frequency:** For less-stable imaging, run more often (*Interval N slices* ~3–5).  
+- **Tracking modes:** Recommended → *Track selected fit global*, *Track selected approx. others*.  
+- **Stigmator:** Usually constant across reference tiles; avoid inducing gradients, especially in *Track selected, fit global* mode.  
+- **Speed:** Disable drift correction if stage precision is better than ~10 µm and imaging is stable.  
+- **Background mode:** Runs full AFSS without applying corrections.  

--- a/gui/autofocus_settings_dlg.ui
+++ b/gui/autofocus_settings_dlg.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>301</width>
-    <height>709</height>
+    <width>601</width>
+    <height>645</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,8 +22,8 @@
   <widget class="QDialogButtonBox" name="buttonBox">
    <property name="geometry">
     <rect>
-     <x>100</x>
-     <y>670</y>
+     <x>400</x>
+     <y>610</y>
      <width>191</width>
      <height>32</height>
     </rect>
@@ -93,6 +93,22 @@
     <bool>false</bool>
    </property>
   </widget>
+    <widget class="QRadioButton" name="radioButton_useAFSS">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>90</y>
+     <width>251</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Use Automated focus/stigmator series</string>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+  </widget>
   <widget class="QGroupBox" name="groupBox_heuristic_af">
    <property name="enabled">
     <bool>true</bool>
@@ -100,7 +116,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>487</y>
+     <y>290</y>
      <width>281</width>
      <height>171</height>
     </rect>
@@ -369,7 +385,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>320</y>
+     <y>120</y>
      <width>281</width>
      <height>158</height>
     </rect>
@@ -500,11 +516,420 @@
     </property>
    </widget>
   </widget>
+  <widget class="QGroupBox" name="groupBox_AFSS_af">
+   <property name="geometry">
+    <rect>
+     <x>310</x>
+     <y>235</y>
+     <width>281</width>
+     <height>370</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Automated Focus/Stigmator Series parameters</string>
+   </property>
+   <widget class="QLabel" name="label_afss_interval">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>13</y>
+      <width>205</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Interval N (slices) :</string>
+    </property>
+   </widget>
+    <widget class="QLabel" name="label_afss_interval_2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>28</y>
+      <width>199</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>AF-> N -> StigX -> N -> StigY -> N</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_interval_2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>43</y>
+      <width>191</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Requires N >= nr. of perturbations </string>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="spinBox_afss_interval">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>20</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>3</number>
+    </property>
+    <property name="maximum">
+     <number>1000</number>
+    </property>
+    <property name="singleStep">
+     <number>1</number>
+    </property>
+    <property name="value">
+     <number>15</number>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="spinBox_afss_offset">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>68</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>0</number>
+    </property>
+    <property name="maximum">
+     <number>10000</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_offset">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>68</y>
+      <width>191</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Delay after start of acquisition (slices):</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_wd">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>110</y>
+      <width>191</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>WD deviation range ±∆ (μm):</string>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="doubleSpinBox_afss_wdDiff">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>110</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="decimals">
+     <number>3</number>
+    </property>
+    <property name="minimum">
+     <double>0.05</double>
+    </property>
+    <property name="maximum">
+     <double>5.0</double>
+    </property>
+    <property name="singleStep">
+     <double>0.1</double>
+    </property>
+    <property name="value">
+     <double>1.5</double>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_stig">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>140</y>
+      <width>141</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Stigmator X/Y ±∆ (%):</string>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="doubleSpinBox_afss_stigXDiff">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>140</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="decimals">
+     <number>2</number>
+    </property>
+	<property name="minimum">
+     <double>0.01</double>
+    </property>
+    <property name="maximum">
+     <double>9.90</double>
+    </property>
+    <property name="singleStep">
+     <double>0.010000000000000</double>
+    </property>
+    <property name="value">
+     <double>0.200000000000000</double>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="doubleSpinBox_afss_stigYDiff">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>140</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="decimals">
+     <number>2</number>
+    </property>
+	<property name="minimum">
+     <double>0.02</double>
+    </property>
+    <property name="maximum">
+     <double>9.90</double>
+    </property>
+    <property name="singleStep">
+     <double>0.010000000000000</double>
+    </property>
+    <property name="value">
+     <double>0.200000000000000</double>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="spinBox_afss_rounds">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>170</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>3</number>
+    </property>
+    <property name="maximum">
+     <number>100</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_rounds">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>170</y>
+      <width>191</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Number of WD/Stigmator perturbations:</string>
+    </property>
+   </widget>
+   <widget class="QComboBox" name="comboBox_afss_consensus_mode">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>200</y>
+      <width>171</width>
+      <height>22</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_consensus_mode">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>200</y>
+      <width>105</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Consensus mode:</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_rmse_limit">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>230</y>
+      <width>191</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Fit precision limit (RMSE):</string>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="doubleSpinBox_afss_rmse_limit">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>230</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="decimals">
+     <number>3</number>
+    </property>
+    <property name="minimum">
+     <double>0.0</double>
+    </property>
+    <property name="maximum">
+     <double>5.0</double>
+    </property>
+    <property name="singleStep">
+     <double>0.01</double>
+    </property>
+    <property name="value">
+     <double>0.25</double>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="spinBox_afss_fails">
+    <property name="geometry">
+     <rect>
+      <x>230</x>
+      <y>260</y>
+      <width>41</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>-1</number>
+    </property>
+    <property name="maximum">
+     <number>100</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_fails">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>260</y>
+      <width>206</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Max. number of failed runs (-1 to disable):</string>
+    </property>
+   </widget>
+	<widget class="QCheckBox" name="checkBox_afss_autostig_active">
+	 <property name="geometry">
+	  <rect>
+	   <x>110</x>
+	   <y>297</y>
+	   <width>151</width>
+	   <height>17</height>
+	  </rect>
+	 </property>
+	 <property name="text">
+	  <string>Enable AutoStigmator</string>
+	 </property>
+	</widget>
+   	<widget class="QCheckBox" name="checkBox_afss_drift_corrected">
+	 <property name="geometry">
+	  <rect>
+	   <x>110</x>
+	   <y>315</y>
+	   <width>101</width>
+	   <height>17</height>
+	  </rect>
+	 </property>
+	 <property name="text">
+	  <string>Drift correction</string>
+	 </property>
+	</widget>
+   	<widget class="QCheckBox" name="checkBox_afss_background_mode">
+	 <property name="geometry">
+	  <rect>
+	   <x>110</x>
+	   <y>333</y>
+	   <width>121</width>
+	   <height>17</height>
+	  </rect>
+	 </property>
+	 <property name="text">
+	  <string>Background mode</string>
+	 </property>
+	</widget>
+   <widget class="QComboBox" name="comboBox_afss_mode">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>300</y>
+      <width>80</width>
+      <height>22</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_mode">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>280</y>
+      <width>75</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Active mode</string>
+    </property>
+   </widget>
+   <widget class="QComboBox" name="comboBox_afss_upcoming_mode">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>342</y>
+      <width>80</width>
+      <height>22</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_afss_upcoming_mode">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>322</y>
+      <width>80</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Upcoming mode</string>
+    </property>
+   </widget>
+  </widget>
+  
   <widget class="QGroupBox" name="groupBox">
    <property name="geometry">
     <rect>
-     <x>9</x>
-     <y>100</y>
+     <x>310</x>
+     <y>10</y>
      <width>281</width>
      <height>211</height>
     </rect>
@@ -517,19 +942,19 @@
      <rect>
       <x>10</x>
       <y>40</y>
-      <width>251</width>
+      <width>260</width>
       <height>16</height>
      </rect>
     </property>
     <property name="text">
-     <string>right clicks in viewport. Currently selected tile(s), in </string>
+     <string>with right clicks in viewport. Currently selected tile(s) </string>
     </property>
    </widget>
    <widget class="QLineEdit" name="lineEdit_refTiles">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>90</y>
+      <y>85</y>
       <width>261</width>
       <height>20</height>
      </rect>
@@ -538,9 +963,9 @@
    <widget class="QComboBox" name="comboBox_trackingMode">
     <property name="geometry">
      <rect>
-      <x>88</x>
+      <x>86</x>
       <y>120</y>
-      <width>181</width>
+      <width>185</width>
       <height>22</height>
      </rect>
     </property>
@@ -568,16 +993,19 @@
      </rect>
     </property>
     <property name="decimals">
-     <number>0</number>
+     <number>3</number>
     </property>
     <property name="minimum">
-     <double>1.000000000000000</double>
+     <double>0.100</double>
     </property>
     <property name="maximum">
-     <double>999.000000000000000</double>
+     <double>999.000</double>
     </property>
+	 <property name="singleStep">
+     <double>0.100</double>
+	</property>
     <property name="value">
-     <double>10.000000000000000</double>
+     <double>1.500</double>
     </property>
    </widget>
    <widget class="QLabel" name="label_max_wd">
@@ -596,26 +1024,26 @@
    <widget class="QDoubleSpinBox" name="doubleSpinBox_maxStigXDiff">
     <property name="geometry">
      <rect>
-      <x>150</x>
+      <x>167</x>
       <y>180</y>
-      <width>61</width>
+      <width>50</width>
       <height>22</height>
      </rect>
     </property>
     <property name="decimals">
-     <number>1</number>
+     <number>2</number>
     </property>
     <property name="minimum">
-     <double>0.100000000000000</double>
+     <double>0.01</double>
     </property>
     <property name="maximum">
-     <double>9.900000000000000</double>
+     <double>9.99</double>
     </property>
     <property name="singleStep">
-     <double>0.100000000000000</double>
+     <double>0.01</double>
     </property>
     <property name="value">
-     <double>1.000000000000000</double>
+     <double>0.20</double>
     </property>
    </widget>
    <widget class="QLabel" name="label_max_astig">
@@ -623,7 +1051,7 @@
      <rect>
       <x>10</x>
       <y>180</y>
-      <width>131</width>
+      <width>170</width>
       <height>20</height>
      </rect>
     </property>
@@ -634,26 +1062,26 @@
    <widget class="QDoubleSpinBox" name="doubleSpinBox_maxStigYDiff">
     <property name="geometry">
      <rect>
-      <x>210</x>
+      <x>221</x>
       <y>180</y>
-      <width>61</width>
+      <width>50</width>
       <height>22</height>
      </rect>
     </property>
     <property name="decimals">
-     <number>1</number>
+     <number>2</number>
     </property>
     <property name="minimum">
-     <double>0.100000000000000</double>
+     <double>0.01</double>
     </property>
     <property name="maximum">
-     <double>9.900000000000000</double>
+     <double>9.99</double>
     </property>
     <property name="singleStep">
-     <double>0.100000000000000</double>
+     <double>0.01</double>
     </property>
     <property name="value">
-     <double>1.000000000000000</double>
+     <double>0.20</double>
     </property>
    </widget>
    <widget class="QLabel" name="label_general_1">
@@ -666,7 +1094,7 @@
      </rect>
     </property>
     <property name="text">
-     <string>Tiles can be (de)selected for (auto)focus tracking with </string>
+     <string>Tiles can be (de)selected for (auto)focus tracking </string>
     </property>
    </widget>
    <widget class="QLabel" name="label_general_3">
@@ -679,7 +1107,7 @@
      </rect>
     </property>
     <property name="text">
-     <string>format #grid_number.#tile_number:</string>
+     <string>in format #grid_number.#tile_number:</string>
     </property>
    </widget>
   </widget>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests
 pywin32
 pyserial
 scipy
+matplotlib
 numpy
 python-dateutil
 scikit-image

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -3218,7 +3218,7 @@ class Acquisition:
             af.process_afss_collections()
 
         # Compute corrections
-        af.fit_afss_collections()
+        af.fit_afss_collections(plot_results=True)
         self.verify_and_log_afss_results(af, af_labels)
 
     def verify_and_log_afss_results(self, af, af_labels):

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -3358,12 +3358,11 @@ class Acquisition:
     def process_afss_autofocus(self):
         """Main function to process AFSS."""
 
+        # Pre-process and compute shifts between image pairs
         af = self.autofocus
-
-        # Run Pre-Processing
         self.solve_deselected_ref_tiles()
         if self.afss_compute_drifts:
-            self.autofocus.afss_compute_pair_drifts()
+            af.afss_compute_pair_shifts()
 
         # Skip if AFSS run incomplete
         if not self.do_afss_corrections:
@@ -3383,7 +3382,6 @@ class Acquisition:
         if af.afss_background_mode:
             af.afss_set_orig_wd_stig()
             self.log('CTRL', 'Background mode active. Resetting original WD/Stig values.')
-
         return
 
     def lock_wd_stig(self):

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -3166,7 +3166,7 @@ class Acquisition:
             })
             af.get_afss_factors()
 
-        # Initialize storage for original settings at series start
+        # Initialize storage for original settings at the beginning of series
         if self.slice_counter == af.afss_next_activation:
             af.afss_wd_stig_orig = {}
         return

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -2558,20 +2558,24 @@ class Acquisition:
                                     'thresholds.',
                                     'error')
 
-                    # AFSS: Add sharpness value of the current tile-image to the correction series:
-                    if (tile_accepted
-                            and tile_index in self.autofocus.afss_data['ref_tiles']
-                            and self.autofocus.afss_active):
+                    # AFSS: Add sharpness value of the current tile-image to the correction series
+                    tile_id = f'{grid_index}.{tile_index}'
+                    af = self.autofocus
 
-                        if tile_index not in self.autofocus.afss_wd_stig_corr:
-                            self.autofocus.afss_wd_stig_corr[tile_index] = {}
+                    if tile_accepted and tile_index in af.afss_data['ref_tiles'] and af.afss_active:
+                        if tile_id not in af.afss_wd_stig_corr:
+                            af.afss_wd_stig_corr[tile_id] = {}
 
-                        entry = {self.slice_counter: [[self.gm[grid_index][tile_index].wd, 0],
-                                                      self.gm[grid_index][tile_index].stig_xy,
-                                                      sharpness,
-                                                      save_path,
-                                                      stddev]}
-                        self.autofocus.afss_wd_stig_corr[tile_index].update(entry)
+                        entry = {
+                            self.slice_counter: [
+                                [self.gm[grid_index][tile_index].wd, 0],
+                                self.gm[grid_index][tile_index].stig_xy,
+                                sharpness,
+                                save_path,
+                                stddev
+                            ]
+                        }
+                        af.afss_wd_stig_corr[tile_id].update(entry)
                 else:
                     # Tile image file could not be loaded
                     self.log(

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -14,7 +14,7 @@ The instance self.acq from class Acquisition is created in MainControls.py. Its
 method run(), which contains the acquisition loop, is started in a thread from
 MainControls.py.
 """
-
+import copy
 import os
 import shutil
 import datetime
@@ -23,6 +23,9 @@ import math
 
 from time import sleep, time
 from statistics import mean
+
+import numpy as np
+
 from image_io import imwrite
 from dateutil.relativedelta import relativedelta
 from qtpy.QtWidgets import QMessageBox
@@ -30,6 +33,8 @@ from qtpy.QtWidgets import QMessageBox
 from constants import Error, Errors
 import constants
 import utils
+
+from Autofocus import FOCUS, STIG_X, STIG_Y
 
 
 class Acquisition:
@@ -155,6 +160,8 @@ class Acquisition:
         notes_file = os.path.join(self.base_dir, self.stack_name + '_notes.txt')
         if not os.path.isfile(notes_file):
             open(notes_file, 'a').close()
+        # Binary masks for AFSS method
+        self.img_masks = {}
 
     def init_acquisition(self):
         # autofocus and autostig status for the current slice
@@ -189,6 +196,12 @@ class Acquisition:
         self.heuristic_af_queue = []
         # Reset current estimators and corrections
         self.autofocus.reset_heuristic_corrections()
+
+        # Perform AFSS computations during cut cycle:
+        self.afss_compute_drifts = False
+        self.do_afss_corrections = False
+        self.autofocus.reset_afss_corrections()
+        self.afss_fail_counter = {FOCUS: -1, STIG_X: -1, STIG_Y: -1}
 
         # Discard previous tile statistics in image inspector that are
         # used for tile-by-tile comparisons and quality checks.
@@ -497,6 +510,15 @@ class Acquisition:
             # Save current grid setup
             gridmap_filename = self.gm.save_tile_positions_to_disk(
                 self.base_dir, timestamp)
+            # Create and store binary circular masks for AFSS
+            for size_id in self.gm.tile_sizes:
+                mask_fn = os.path.join(
+                    self.base_dir, 'meta', 'stats', size_id + '.tif')
+                mask = utils.create_mask(self.gm.tile_sizes[size_id])
+                try:
+                    utils.save_mask(mask, mask_fn)
+                except Exception as _:
+                    self.error_state == Error.autofocus_afss            
             # Create main log file, in which all entries are saved.
             # No line limit.
             self.main_log_filename = os.path.join(
@@ -639,6 +661,7 @@ class Acquisition:
 
         self.set_up_acq_subdirectories()
         self.set_up_acq_logs()
+        self.img_masks = utils.load_masks(os.path.join(self.base_dir, 'meta', 'stats'))
 
         # Proceed if no error has occurred during setup of folders and logs
         if self.error_state == Error.none:
@@ -652,12 +675,16 @@ class Acquisition:
                 self.main_log_file.write(
                     '\n*** STACK ACQUISITION RESTARTED ***\n')
                 self.add_to_main_log('CTRL: Stack restarted.')
+                if self.autofocus.afss_active and self.autofocus.method != 4:
+                    self.autofocus.afss_active = False                
                 self.acq_paused = False
+                self.autofocus.acquisition_running = True                
             else:
                 utils.log_info('CTRL', 'Stack started.')
                 self.main_log_file.write(
                     '\n*** STACK ACQUISITION STARTED ***\n')
                 self.add_to_main_log('CTRL: Stack started.')
+                self.autofocus.acquisition_running = True
 
             if self.use_mirror_drive:
                 utils.log_info(
@@ -739,6 +766,10 @@ class Acquisition:
                 self.sem.set_beam_blanking(True)
                 sleep(1)
 
+            # Check preconditions for AFSS autofocus method
+            if self.use_autofocus and self.autofocus.method == 4:
+                _ = self.afss_validate_ref_tiles()
+                
             # Initialize focus parameters for all grids with defaults, but only
             # for those tiles that have not yet been initialized (there may be
             # existing focus settings from a previous run that must not be
@@ -824,6 +855,18 @@ class Acquisition:
 
             if self.gm.array_mode:
                 self.sem.set_mode_normal()
+                
+            if self.use_autofocus and self.autofocus.method == 4:
+                self.afss_validate_ref_tiles()
+
+                # Define first activation of the AFSS series in case of non-zero slice offset
+                if self.autofocus.afss_active:
+                    self.autofocus.afss_next_activation = self.slice_counter + self.autofocus.afss_offset
+                    d = {FOCUS: 'Focus', STIG_X: 'Stigmator X', STIG_Y: 'Stigmator Y'}
+                    msg = f'Automated {d[self.autofocus.afss_mode]} series will start ' \
+                          f'at slice: {self.autofocus.afss_next_activation}'
+                    self.log('CTRL', msg)
+
 
         # ========================= ACQUISITION LOOP ===========================
 
@@ -982,6 +1025,11 @@ class Acquisition:
         if self.stack_completed and not self.number_slices == 0:
             self.log('CTRL', 'Stack completed.')
             self.main_controls_trigger.transmit('COMPLETION STOP')
+            self.autofocus.acquisition_running = False
+            if self.autofocus.afss_active:
+                self.autofocus.afss_set_orig_wd_stig()
+                self.autofocus.reset_afss_corrections()
+                self.log('CTRL', 'Resetting original WD/Stig values to reference tiles.')
             if self.use_email_monitoring:
                 # Send notification email
                 msg_subject = 'Stack ' + self.stack_name + ' COMPLETED.'
@@ -1000,6 +1048,15 @@ class Acquisition:
 
         if self.acq_paused:
             self.log('CTRL', 'Stack paused.')
+            # Reset AFSS series and set original WD/Stig to reference tiles if the acquisition is paused during AFSS run
+            self.autofocus.acquisition_running = False
+            if self.autofocus.afss_active:
+                self.autofocus.afss_set_orig_wd_stig()
+                self.autofocus.reset_afss_corrections()
+                self.log('CTRL', 'Resetting original WD/Stig values to reference tiles.')
+                self.autofocus.afss_active = False
+            # for AFSS delay purposes
+            self.autofocus.afss_next_activation = self.slice_counter + self.autofocus.afss_offset
 
         # Update acquisition status in Main Controls GUI
         self.main_controls_trigger.transmit('ACQ NOT IN PROGRESS')
@@ -1224,6 +1281,8 @@ class Acquisition:
                 ' nm cutting thickness).')
             # Do the full cut cycle (near, cut, retract, clear)
             self.microtome.do_full_cut()
+            # Process tiles for AFSS autofocus
+            self.process_afss_autofocus()
             # Process tiles for heuristic autofocus during cut
             if self.heuristic_af_queue:
                 self.process_heuristic_af_queue()
@@ -1260,7 +1319,7 @@ class Acquisition:
                 # microtome's error state.
                 self.error_state = self.microtome.error_state
                 self.microtome.reset_error_state()
-        if self.error_state != Error.none and self.error_state != Error.wd_stig_difference:
+        if self.error_state != Error.none and self.error_state != Error.wd_stig_difference and self.error_state != Error.autofocus_afss:
             self.log('CTRL', 'Error during cut cycle.', 'error')
             self.log(
                 'STAGE',
@@ -1632,7 +1691,7 @@ class Acquisition:
             if os.path.isfile(ov_save_path):
 
                 # Inspect the acquired image
-                (ov_img, mean, stddev,
+                (ov_img, mean, stddev, sharpness,
                  range_test_passed,
                  load_error, load_exception, grab_incomplete) = (
                     self.img_inspector.process_ov(ov_save_path,
@@ -1820,6 +1879,8 @@ class Acquisition:
                     break
                 self.do_autofocus_before_grid_acq(grid_index)
             self.gm.fit_apply_aberration_gradient()
+        # For Automated Focus/Stigmator series (method 4), apply the WD/Stig deltas
+        self.afss_handle_series()
         for grid_index, grid in enumerate(self.gm):
             grid_label = grid.get_label(grid_index)
             self.grid_current_index = grid_index
@@ -1922,7 +1983,7 @@ class Acquisition:
         # Otherwise wd_default, stig_x_default, and stig_y_default are used.
         adjust_wd_stig = (
             grid.use_wd_gradient
-            or (self.use_autofocus and self.autofocus.tracking_mode < 2))
+            or (self.use_autofocus and self.autofocus.tracking_mode < 5))
         self.tile_wd, self.tile_stig_x, self.tile_stig_y = 0, 0, 0
 
         # The grid's acquisition settings will be applied before the first
@@ -2154,7 +2215,18 @@ class Acquisition:
                     'ARRAY SET SECTION STATE',
                     'acquired',
                     [grid_index])
-
+        
+        # AFSS: reset original WDs of tracked tiles before grid is acquired again
+        # Skip if AFSS series has been successfully acquired and will be processed.
+        # Also skip if acquisition has been paused (solved already by acq_paused)
+        if self.autofocus.afss_active and not self.do_afss_corrections and not self.acq_paused:
+            gr_ind = self.autofocus.afss_grid_ind
+            for tile_index in self.autofocus.afss_data['ref_tiles']:
+                key = f'{gr_ind}.{tile_index}'
+                self.gm[gr_ind][tile_index].wd = self.autofocus.afss_wd_stig_orig[key][0][0]
+                self.gm[gr_ind][tile_index].stig_xy = self.autofocus.afss_wd_stig_orig[key][1]
+                    
+                    
     def acquire_tile(self, grid_index, tile_index,
                      adjust_wd_stig=False, adjust_acq_settings=False,
                      overwrite=False):
@@ -2337,6 +2409,7 @@ class Acquisition:
                 Error.autofocus_smartsem,
                 Error.autofocus_heuristic,
                 Error.wd_stig_difference,
+                Error.autofocus_afss,
             ]:
                 # Check mag if locked
                 if self.mag_locked:
@@ -2392,14 +2465,29 @@ class Acquisition:
 
             # Check if image was saved and process it
             if os.path.isfile(save_path):
+
+                # Identify appropriate image mask for quality monitor (based on image width value)
+                tile_width, tile_height = self.gm[grid_index].frame_size
+                mask_key = [key for key, size in self.gm.tile_sizes.items() if size[0] == tile_width][0]
+                if mask_key:
+                    masking = True
+                else:
+                    masking = False
+                    mask_key = 'mask_0k'  # dummy mask key for 'process_tile' function in case no
+                    # compatible mask (0k : 8k) could be found
+                mask = self.img_masks[mask_key]
+
                 start_time = time()
-                (tile_img, mean, stddev,
+                (tile_img, mean, stddev, sharpness,
                  range_test_passed, slice_by_slice_test_passed, tile_selected,
-                 load_error, load_exception,
-                 grab_incomplete, frozen_frame_error) = (
+                 load_error, load_exception, grab_incomplete, frozen_frame_error) = (
                     self.img_inspector.process_tile(save_path,
-                                                    grid_index, tile_index,
-                                                    self.slice_counter))
+                                                    grid_index,
+                                                    tile_index,
+                                                    self.slice_counter, 
+                                                    mask,
+                                                    masking)
+                )
                 # Time the duration of process_tile()
                 end_time = time()
                 inspect_duration = end_time - start_time
@@ -2425,6 +2513,7 @@ class Acquisition:
                         Error.autofocus_smartsem,
                         Error.autofocus_heuristic,
                         Error.wd_stig_difference,
+                        Error.autofocus_afss,
                     ]:
                         # Don't accept tile if autofocus error has ocurred
                         tile_accepted = False
@@ -2468,6 +2557,21 @@ class Acquisition:
                                     'Tile above mean/SD slice-by-slice '
                                     'thresholds.',
                                     'error')
+
+                    # AFSS: Add sharpness value of the current tile-image to the correction series:
+                    if (tile_accepted
+                            and tile_index in self.autofocus.afss_data['ref_tiles']
+                            and self.autofocus.afss_active):
+
+                        if tile_index not in self.autofocus.afss_wd_stig_corr:
+                            self.autofocus.afss_wd_stig_corr[tile_index] = {}
+
+                        entry = {self.slice_counter: [[self.gm[grid_index][tile_index].wd, 0],
+                                                      self.gm[grid_index][tile_index].stig_xy,
+                                                      sharpness,
+                                                      save_path,
+                                                      stddev]}
+                        self.autofocus.afss_wd_stig_corr[tile_index].update(entry)
                 else:
                     # Tile image file could not be loaded
                     self.log(
@@ -2958,6 +3062,329 @@ class Acquisition:
         self.log("Array-CTRL", "Applying WD/STIG to the grid")
         grid.set_wd_stig_from_calibrated_points()
 
+    def solve_deselected_ref_tiles(self):
+        # Collect tile-ids to delete from active AFSS series if user deselected them
+        keys_to_delete = []
+        for tile_id, entries in self.autofocus.afss_wd_stig_corr.items():
+            if self.slice_counter not in entries:
+                keys_to_delete.append(tile_id)
+        for tile_id in keys_to_delete:
+            del self.autofocus.afss_wd_stig_corr[tile_id]
+        return
+
+    def afss_error_state(self) -> None:
+        """Reset autofocus corrections, set the AFSS as inactive, and handle the error state."""
+        self.autofocus.reset_afss_corrections()
+        self.autofocus.afss_active = False
+        self.error_state = Error.autofocus_afss
+        self.pause_acquisition(1)
+
+    def afss_validate_ref_tiles(self):
+        """Ensures AFSS reference tiles are defined on exactly one grid.
+
+        Validates that reference tiles exist on a single grid for use with the
+        'Track selected, fit others (global)' autofocus tracking mode. Multiple
+        grids with reference tiles can cause loss of valid working distances and
+        Stigmator settings.
+
+        Returns:
+            A tuple containing:
+            - grid_index (int): The index of the grid with reference tiles.
+            - ref_tiles_ids (List[int]): The list of reference tile IDs for the identified grid.
+
+        Raises:
+            None: If validation fails (e.g., no reference tiles or multiple grids with ref. tiles),
+            returns `None` and logs an error.
+        """
+        # Identify grids with AFSS reference tiles
+        ref_tile_keys = {}
+        for grid_index in range(self.gm.number_grids):
+            ref_tiles = self.gm[grid_index].autofocus_ref_tiles()
+            if ref_tiles:
+                ref_tile_keys[grid_index] = ref_tiles
+
+        if not ref_tile_keys:
+            self.log('CTRL', "No grid contains AFSS reference tiles!")
+            self.afss_error_state()
+            return None  # Indicates no reference tiles found
+
+        if len(ref_tile_keys) != 1:
+            self.log('CTRL', "AFSS requires reference tiles from one grid only!")
+            self.afss_error_state()
+            return None  # Indicates validation failure
+
+        grid_index, ref_tiles_ids = next(iter(ref_tile_keys.items()))
+        return grid_index, ref_tiles_ids
+
+    def afss_handle_series(self):
+        """Handle Automated Focus/Stigmator Series (AFSS) for method 4."""
+        if not (self.use_autofocus and self.autofocus.method == 4):
+            return
+
+        self.afss_compute_drifts = False
+        self.do_afss_corrections = False
+        af = self.autofocus
+
+        # Call the new function to identify and validate reference tiles
+        valid_grid = self.afss_validate_ref_tiles()
+        if valid_grid is None:
+            return  # Exit if validation fails
+
+        # Extract grid index and reference tile IDs
+        grid_index, ref_tiles_ids = valid_grid
+        af.afss_grid_ind = grid_index
+
+        # Postpone AFSS activation if offset is zero and some ref. tiles are already imaged
+        if af.afss_offset == 0 and any(tile in self.tiles_acquired for tile in ref_tiles_ids):
+            af.afss_next_activation += 1
+            self.log('CTRL', "AFSS activation postponed (some ref. tiles already imaged)")
+
+        # Determine if AFSS series is active
+        series_active = (
+                af.afss_next_activation <= self.slice_counter <= af.afss_next_activation + af.afss_rounds
+                and not self.acq_paused
+        )
+        af.afss_active = self.use_autofocus and af.method == 4 and series_active
+
+        # Handle AFSS perturbations if series is active
+        af.afss_current_round = self.slice_counter - af.afss_next_activation
+        if af.afss_active:
+            self.afss_initialize_series(ref_tiles_ids)
+            self.afss_apply_perturbations(grid_index)
+
+    def afss_initialize_series(self, afss_ref_tile_ids):
+        # Stores nominal AFSS settings at series start and computes WD/STIG multiplication factors
+        af = self.autofocus
+        if af.afss_current_round == 0:
+            af.afss_data.update({
+                'dwd': af.afss_wd_delta,
+                'dsx': af.afss_stig_x_delta,
+                'dsy': af.afss_stig_y_delta,
+                'afss_rounds': af.afss_rounds,
+                'ref_tiles': afss_ref_tile_ids,
+            })
+            af.get_afss_factors()
+
+        # Initialize storage for original settings at series start
+        if self.slice_counter == af.afss_next_activation:
+            af.afss_wd_stig_orig = {}
+        return
+
+    def afss_apply_perturbations(self, grid_index):
+        """Apply AFSS perturbations and manage series state."""
+
+        # Alias
+        af = self.autofocus
+
+        # Apply perturbations for each reference tile
+        delta_wd, delta_stig = 0, np.asarray([0, 0])
+        for tile_index in af.afss_data['ref_tiles']:
+            tile_key = f'{grid_index}.{tile_index}'
+            tile = self.gm[grid_index][tile_index]
+
+            # Store original WD and Stigmator settings
+            if self.slice_counter == af.afss_next_activation:
+                af.afss_wd_stig_orig[tile_key] = [[tile.wd, 0], np.array(tile.stig_xy)]
+
+            # Apply perturbation based on mode
+            factor = af.afss_perturbation_series[tile_index][af.afss_current_round]
+            if af.afss_mode == FOCUS:
+                delta_wd = factor * af.afss_data['dwd']
+                tile.wd += delta_wd
+            elif af.afss_mode == STIG_X:
+                delta_stig = np.asarray((factor * af.afss_data['dsx'], 0))
+                tile.stig_xy = np.asarray(tile.stig_xy) + delta_stig
+            elif af.afss_mode == STIG_Y:
+                delta_stig = np.asarray((0, factor * af.afss_data['dsy']))
+                tile.stig_xy = np.asarray(tile.stig_xy) + delta_stig
+
+        # Log perturbation details
+        self.log('CTRL', af.format_afss_message(delta_wd, delta_stig))
+
+        # Enable drift computation for non-reference slices in series
+        if 0 < af.afss_current_round < af.afss_data['afss_rounds']:
+            self.afss_compute_drifts = True
+
+        # Enable corrections at series end
+        self.do_afss_corrections = af.afss_current_round == af.afss_data['afss_rounds'] - 1
+
+        return
+
+    def compute_and_apply_afss_results(self, af, af_labels):
+        """Handles processing of good AFSS fits."""
+        self.log('CTRL', f'Processing {af_labels[af.afss_mode]} series.')
+        if af.afss_drift_corrected:
+            af.process_afss_collections()
+
+        # Compute corrections
+        af.fit_afss_collections()
+        self.verify_and_log_afss_results(af, af_labels)
+
+    def verify_and_log_afss_results(self, af, af_labels):
+        """Verifies AFSS results and logs them accordingly."""
+        nr_good_fits, rej_fits, diffs_passed, rej_thr = af.afss_verify_results()
+
+        if rej_fits:
+            self.log_failed_afss_fits(rej_fits)
+
+        if diffs_passed and nr_good_fits > 0:
+            self.apply_and_log_afss_corr(af)
+        else:
+            # AFSS results did not pass thresholding or no good fit was found:
+            rej_tiles = copy.deepcopy(rej_thr)
+            self.handle_afss_rejected_fits(af, af_labels, nr_good_fits, diffs_passed, rej_thr, rej_tiles)
+
+    def log_failed_afss_fits(self, rej_fits):
+        """Logs AFSS ref. tiles that failed to meet threshold."""
+        self.log('CTRL', f'Reliable results could not be found for following tiles:')
+        for val in rej_fits.values():
+            self.log('CTRL', val[1])
+
+    def apply_and_log_afss_corr(self, af):
+        """Applies AFSS corrections and log results based on consensus mode."""
+        log_msgs = af.apply_afss_corrections()
+
+        if af.afss_filter_outliers and af.afss_stats['n_outliers'] != 0:
+            self.log('CTRL', f'Discarding {af.afss_stats["n_outliers"]} outlier(s) from averaging.')
+
+        self.log_afss_verified_stats(af)
+
+        if af.afss_consensus_mode == 1 or (af.afss_consensus_mode == 2 and af.afss_mode == FOCUS):
+            self.log_afss_specific_corrections(log_msgs)
+        else:
+            self.log_afss_avg_corrections(af)
+
+        # Finalize successful series
+        self.close_passed_afss_series(af)
+        return
+
+    def log_afss_verified_stats(self, af):
+        # Log info about results of either Focus or Stigmator series
+        n_fail = af.afss_stats['n_failed']
+        n_lim = af.afss_stats['n_out_of_lim']
+        n_outs = af.afss_stats['n_outliers']
+        msg = f'Amount of failed/over RMSE limit/filtered fits: {n_fail}/{n_lim}/{n_outs}'
+        self.log('CTRL', msg)
+
+    def close_passed_afss_series(self, af):
+        # Reset fail counter of current afss mode if AFSS run was successful
+        self.afss_fail_counter[af.afss_mode] = -1
+        af.afss_mode = af.next_afss_mode()
+        af.afss_upcoming_mode = af.next_afss_mode()
+
+    def log_afss_specific_corrections(self, log_msgs):
+        """Applies corrections in consensus mode."""
+        self.log('CTRL', 'Applying corrections to all tracked tiles:')
+        for msg in log_msgs.values():
+            self.add_to_main_log(msg)
+            utils.log_info(msg.split(':')[0], msg.split(':')[1][1:])
+
+    def log_afss_avg_corrections(self, af):
+        """Applies average corrections."""
+        mean_diff = af.afss_stats['avg']
+        dx = {FOCUS: ['WD', f'{mean_diff * 10 ** 6:.3f} um'],
+              STIG_X: ['StigX', f'{mean_diff:.3f} %'],
+              STIG_Y: ['StigY', f'{mean_diff:.3f} %']}
+        msg = f'Applying average {dx[af.afss_mode][0]} correction {dx[af.afss_mode][1]} to all tracked tiles.'
+        self.log('CTRL', msg)
+
+    def handle_afss_rejected_fits(self, af, af_labels, diffs_passed, nr_good_fits, rej_thr, rejected_tiles):
+        """Handles rejected fits, logging, and resetting values."""
+        if nr_good_fits == -1:
+            self.log_afss_verified_stats(af)
+            self.log('CTRL', f'{af_labels[af.afss_mode]} average correction could not be estimated.')
+            self.log('CTRL', f'Resetting original {af_labels[af.afss_mode]} values.')
+            af.afss_set_orig_wd_stig()
+        elif nr_good_fits == 0:
+            self.log('CTRL', 'Interpolation of all tracked tiles failed.')
+            self.log('CTRL', f'Resetting original {af_labels[af.afss_mode]} values.')
+            af.afss_set_orig_wd_stig()
+        elif not diffs_passed:
+            # Handles situations when WD/STIG corrections are out of permitted ranges
+            if af.afss_consensus_mode == 0 or (af.afss_consensus_mode == 2 and af.afss_mode != FOCUS):
+                self.afss_avg_out_of_range(af, af_labels, rej_thr)
+            else:
+                self.afss_spec_diffs_out_of_range(af, af_labels, rej_thr, rejected_tiles)
+
+        self.close_not_passed_afss_series(af)
+        return
+
+    def afss_avg_out_of_range(self, af, af_labels, rej_thr):
+        msg_0 = list(rej_thr.values())[0][1]
+        msg_1 = f'{af_labels[af.afss_mode]} average correction is out of the permitted range!'
+        msg_2 = f'Resetting original {af_labels[af.afss_mode]} values.'
+        for msg in [msg_0, msg_1, msg_2]:
+            self.log('CTRL', msg)
+
+        af.afss_set_orig_wd_stig()
+        return
+
+    def afss_spec_diffs_out_of_range(self, af, af_labels, rej_thr, rejected_tiles):
+
+        # Apply corrections and log them
+        log_msgs = af.apply_afss_corrections()
+        for msg in log_msgs.values():
+            self.add_to_main_log(msg)
+            utils.log_info(msg.split(':')[0], msg.split(':')[1][1:])
+
+        msg = f'{af_labels[af.afss_mode]} corrections of following tiles discarded (out of permitted range):'
+        self.log('CTRL', msg)
+
+        # Reset corrections that are out of permitted range and ensure that orig values are reset
+        for tile_key, val in rej_thr.items():
+            self.log('CTRL', val[1])
+            grid_index, tile_index = map(int, str.split(tile_key, '.'))
+            orig_wd = rejected_tiles[tile_key][2][0][0]
+            orig_stig_xy = rejected_tiles[tile_key][2][1]
+            self.gm[grid_index][tile_index].wd = orig_wd
+            af.afss_wd_stig_orig[tile_key][0][0] = orig_wd
+            self.gm[grid_index][tile_index].stig_xy = orig_stig_xy
+            af.afss_wd_stig_orig[tile_key][1] = orig_stig_xy
+
+    def close_not_passed_afss_series(self, af):
+        # Log unsuccessful AFSS run
+        self.afss_fail_counter[af.afss_mode] += 1
+        # Comment-out next line if same AFSS mode should be repeated when run unsuccessful
+        af.afss_mode = af.next_afss_mode()
+
+        # Safety feature in case of AFSS failed too many times (disabled if user selected -1)
+        afss_safe_mode = af.afss_max_fails != -1  # Safety feature
+        if any(v == af.afss_max_fails for v in self.afss_fail_counter.values()) \
+                and afss_safe_mode:
+            self.log('CTRL', 'Automated Focus/Stig series failed too many times.')
+            self.afss_error_state()
+
+    def process_afss_autofocus(self):
+        """Main function to process AFSS."""
+        # Initial Setup
+        af = self.autofocus
+        af_labels = {FOCUS: 'Focus', STIG_X: 'Stigmator X', STIG_Y: 'Stigmator Y'}
+
+        # Run Pre-Processing
+        self.solve_deselected_ref_tiles()
+        if self.afss_compute_drifts:
+            self.autofocus.afss_compute_pair_drifts()
+
+        # Skip if AFSS run incomplete
+        if not self.do_afss_corrections:
+            return
+
+        # Process results if good fits
+        self.compute_and_apply_afss_results(af, af_labels)
+
+        # Finalize processing
+        af.reset_afss_corrections()
+        af.afss_active = False
+        af.afss_next_activation += af.interval
+        if self.slice_counter + 1 != self.number_slices and self.error_state is not Error.autofocus_afss:
+            self.log('CTRL', f'{af_labels[af.afss_mode]} run will be triggered at slice {af.afss_next_activation}')
+
+        # Reset original WD/STIG values if background mode is checked
+        if af.afss_background_mode:
+            af.afss_set_orig_wd_stig()
+            self.log('CTRL', 'Background mode active. Resetting original WD/Stig values.')
+
+        return
 
     def lock_wd_stig(self):
         self.locked_wd = self.sem.get_wd()

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -30,12 +30,9 @@ from image_io import imwrite
 from dateutil.relativedelta import relativedelta
 from qtpy.QtWidgets import QMessageBox
 
-from constants import Error, Errors
+from constants import Error, Errors, FOCUS, STIG_X, STIG_Y, AFSS_LABELS
 import constants
 import utils
-
-from Autofocus import FOCUS, STIG_X, STIG_Y, AFSS_LABELS
-
 
 class Acquisition:
 
@@ -1045,14 +1042,14 @@ class Acquisition:
 
         if self.acq_paused:
             self.log('CTRL', 'Stack paused.')
-            # Reset AFSS series and set original WD/Stig to reference tiles if the acquisition is paused during AFSS run
+            # Reset AFSS series and set original WD/Stig to ref. tiles if the acquisition is paused during AFSS run
             self.autofocus.acquisition_running = False
             if self.autofocus.afss_active:
                 self.autofocus.afss_set_orig_wd_stig()
                 self.autofocus.reset_afss_corrections()
                 self.log('CTRL', 'Resetting original WD/Stig values to reference tiles.')
                 self.autofocus.afss_active = False
-            # for AFSS delay purposes
+            # For delayed AFSS activation
             self.autofocus.afss_next_activation = self.slice_counter + self.autofocus.afss_offset
 
         # Update acquisition status in Main Controls GUI
@@ -3374,8 +3371,10 @@ class Acquisition:
         # Finalize processing
         af.reset_afss_corrections()
         af.afss_active = False
+        acq_active = self.acq_paused or self.stack_completed
+        afss_err = self.error_state is not Error.autofocus_afss
         af.afss_next_activation += af.interval
-        if self.slice_counter + 1 != self.number_slices and self.error_state is not Error.autofocus_afss:
+        if self.slice_counter + 1 != self.number_slices and acq_active and not afss_err:
             self.log('CTRL', f'{AFSS_LABELS[af.afss_mode]} run will be triggered at slice {af.afss_next_activation}')
 
         # Reset original WD/STIG values if background mode is checked

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -34,7 +34,7 @@ from constants import Error, Errors
 import constants
 import utils
 
-from Autofocus import FOCUS, STIG_X, STIG_Y
+from Autofocus import FOCUS, STIG_X, STIG_Y, AFSS_LABELS
 
 
 class Acquisition:
@@ -855,17 +855,14 @@ class Acquisition:
 
             if self.gm.array_mode:
                 self.sem.set_mode_normal()
-                
+
+            # Define first activation of the AFSS series in case of non-zero slice offset
             if self.use_autofocus and self.autofocus.method == 4:
                 self.afss_validate_ref_tiles()
-
-                # Define first activation of the AFSS series in case of non-zero slice offset
-                if self.autofocus.afss_active:
-                    self.autofocus.afss_next_activation = self.slice_counter + self.autofocus.afss_offset
-                    d = {FOCUS: 'Focus', STIG_X: 'Stigmator X', STIG_Y: 'Stigmator Y'}
-                    msg = f'Automated {d[self.autofocus.afss_mode]} series will start ' \
-                          f'at slice: {self.autofocus.afss_next_activation}'
-                    self.log('CTRL', msg)
+                self.autofocus.afss_next_activation = self.slice_counter + self.autofocus.afss_offset
+                msg = f'Automated {AFSS_LABELS[self.autofocus.afss_mode]} series will start ' \
+                      f'at slice: {self.autofocus.afss_next_activation}'
+                self.log('CTRL', msg)
 
 
         # ========================= ACQUISITION LOOP ===========================
@@ -3360,9 +3357,8 @@ class Acquisition:
 
     def process_afss_autofocus(self):
         """Main function to process AFSS."""
-        # Initial Setup
+
         af = self.autofocus
-        af_labels = {FOCUS: 'Focus', STIG_X: 'Stigmator X', STIG_Y: 'Stigmator Y'}
 
         # Run Pre-Processing
         self.solve_deselected_ref_tiles()
@@ -3374,14 +3370,14 @@ class Acquisition:
             return
 
         # Process results if good fits
-        self.compute_and_apply_afss_results(af, af_labels)
+        self.compute_and_apply_afss_results(af, AFSS_LABELS)
 
         # Finalize processing
         af.reset_afss_corrections()
         af.afss_active = False
         af.afss_next_activation += af.interval
         if self.slice_counter + 1 != self.number_slices and self.error_state is not Error.autofocus_afss:
-            self.log('CTRL', f'{af_labels[af.afss_mode]} run will be triggered at slice {af.afss_next_activation}')
+            self.log('CTRL', f'{AFSS_LABELS[af.afss_mode]} run will be triggered at slice {af.afss_next_activation}')
 
         # Reset original WD/STIG values if background mode is checked
         if af.afss_background_mode:

--- a/src/Acquisition.py
+++ b/src/Acquisition.py
@@ -3233,7 +3233,7 @@ class Acquisition:
         else:
             # AFSS results did not pass thresholding or no good fit was found:
             rej_tiles = copy.deepcopy(rej_thr)
-            self.handle_afss_rejected_fits(af, af_labels, nr_good_fits, diffs_passed, rej_thr, rej_tiles)
+            self.handle_afss_rejected_fits(af, af_labels, diffs_passed, nr_good_fits, rej_thr, rej_tiles)
 
     def log_failed_afss_fits(self, rej_fits):
         """Logs AFSS ref. tiles that failed to meet threshold."""
@@ -3264,7 +3264,7 @@ class Acquisition:
         n_fail = af.afss_stats['n_failed']
         n_lim = af.afss_stats['n_out_of_lim']
         n_outs = af.afss_stats['n_outliers']
-        msg = f'Amount of failed/over RMSE limit/filtered fits: {n_fail}/{n_lim}/{n_outs}'
+        msg = f'Failed/over RMSE limit/filtered fits: {n_fail}/{n_lim}/{n_outs}'
         self.log('CTRL', msg)
 
     def close_passed_afss_series(self, af):
@@ -3291,8 +3291,8 @@ class Acquisition:
 
     def handle_afss_rejected_fits(self, af, af_labels, diffs_passed, nr_good_fits, rej_thr, rejected_tiles):
         """Handles rejected fits, logging, and resetting values."""
+        self.log_afss_verified_stats(af)
         if nr_good_fits == -1:
-            self.log_afss_verified_stats(af)
             self.log('CTRL', f'{af_labels[af.afss_mode]} average correction could not be estimated.')
             self.log('CTRL', f'Resetting original {af_labels[af.afss_mode]} values.')
             af.afss_set_orig_wd_stig()

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -15,7 +15,6 @@ intervals on selected tiles. (2) Heuristic algorithm as used in Briggman
 et al. (2011), described in Appendix A of Binding et al. (2012).
 """
 
-from copy import deepcopy
 import json
 from math import sqrt, exp, sin, cos
 from matplotlib import pyplot as plt

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -473,18 +473,14 @@ class Autofocus:
         self.afss_stats = {'avg': 0, 'n_failed': 0, 'n_out_of_lim': 0, 'n_outliers': 0}
 
         # Remove corrupted results from optima dict due unsuccessful fit(s)
-        d = deepcopy(self.afss_wd_stig_corr_optima)
-        for t, vals in list(d.items()):
-            rmse_val = vals[1]
-            if rmse_val == -1:
-                self.afss_stats['n_failed'] += 1
-                del d[t]
-            if rmse_val > self.afss_rmse_limit:
-                self.afss_stats['n_out_of_lim'] += 1
-                del d[t]
+        valid_fits = {
+            t: vals
+            for t, vals in self.afss_wd_stig_corr_optima.items()
+            if vals[1] != -1 and vals[1] <= self.afss_rmse_limit
+        }
 
         # Get optimal WD/Stig differences for set of valid results
-        for tile_key, vals in d.items():
+        for tile_key, vals in valid_fits.items():
             valid_diffs[tile_key] = vals[0] - self.afss_wd_stig_orig[tile_key][TBL[m][0]][TBL[m][1]]
 
         # Remove outliers from set of optimal WD/Stig differences
@@ -518,16 +514,19 @@ class Autofocus:
 
 
     def afss_verify_results(self) -> Tuple[int, dict, bool, dict]:
-        rej_fits = {}
-        rej_thr = {}
-        diffs_passed = False
-        num_good_fits = -1
+        rej_fits: dict = {}
+        rej_thr: dict = {}
+        diffs_passed: bool = False
+        num_good_fits: int = -1
 
-        LUT = {FOCUS: (0, 0, self.max_wd_diff, 10 ** 6, 'WD', 'um'),
-               STIG_X: (1, 0, self.max_stig_x_diff, 1, 'StigX', '%'),
-               STIG_Y: (1, 1, self.max_stig_y_diff, 1, 'StigY', '%')}
+        # Lookup table for mode attributes: (row_idx, col_idx, max_diff, scale_factor, label, unit)
+        LUT = {
+            FOCUS: (0, 0, self.max_wd_diff, 10 ** 6, 'WD', 'um'),
+            STIG_X: (1, 0, self.max_stig_x_diff, 1, 'StigX', '%'),
+            STIG_Y: (1, 1, self.max_stig_y_diff, 1, 'StigY', '%')
+        }
 
-        # Determine averaging mode
+        # Determine if averaging mode is active
         is_avg_mode = (self.afss_consensus_mode == 0 or
                        (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS))
 
@@ -537,31 +536,38 @@ class Autofocus:
 
         # Remove corrupted results from optima dict, due unsuccessful fit(s)
         opts = self.afss_wd_stig_corr_optima
-        for t, vals in list(opts.items()):
-            rmse_val = vals[1]
-            if rmse_val > self.afss_rmse_limit or rmse_val == -1:
+        for t, (_, rmse_val) in list(opts.items()):
+            if rmse_val == -1:
+                self.afss_stats['n_failed'] += 1
+                rej_fits[t] = (rmse_val, f'Tile {t} fit failed.')
                 del opts[t]
+            if rmse_val > self.afss_rmse_limit:
+                self.afss_stats['n_out_of_lim'] += 1
                 rej_fits[t] = (rmse_val, f'Tile {t} fit rejected.')
+                del opts[t]
 
         num_good_fits = len(opts)
         if num_good_fits == 0:
             diffs_passed = False
             return num_good_fits, rej_fits, diffs_passed, rej_thr
 
-        attr = LUT[self.afss_mode]
+        row_idx, col_idx, max_diff, scale, label, unit = LUT[self.afss_mode]
 
         if is_avg_mode:
-            if np.isnan(self.afss_avg_corr):
+            avg_corr = self.afss_avg_corr
+            if np.isnan(avg_corr):
                 num_good_fits = -1
                 diffs_passed = False
             else:
-                diff = abs(self.afss_avg_corr)
-                d1 = round(self.afss_avg_corr * attr[3], 3)
-                d2 = round(attr[2] * attr[3], 3)
-                unit = attr[5]
-                msg = f'Average {attr[4]} correction: {d1} {unit} (Limit: {d2} {unit})'
-                if diff > attr[2]:  # Average diff is out of range
-                    rej_thr[list(opts.keys())[0]] = (d1, msg)
+                diff = abs(avg_corr)
+                avg_scl = round(avg_corr * scale, 3)
+                lim_scl = round(max_diff * scale, 3)
+                msg = f'Average {label} correction: {avg_scl} {unit} (Limit: {lim_scl} {unit})'
+                # Average diff is out of range
+                if diff > max_diff:
+                    first_tile = next(iter(opts)) if opts else None
+                    if first_tile:
+                        rej_thr[first_tile] = (avg_scl, msg)
                 else:
                     diffs_passed = True
             return num_good_fits, rej_fits, diffs_passed, rej_thr
@@ -569,18 +575,17 @@ class Autofocus:
         # Check that computed optimal WD and Stigmator values
         # of all reference tiles are below WD/Stig thresholds
         diffs_passed = True
-        for tile_key, opt in opts.items():
-            i1, i2 = attr[0], attr[1]
-            diff = opt[0] - self.afss_wd_stig_orig[tile_key][i1][i2]
+        orig_values = self.afss_wd_stig_orig
+        for t, opt in opts.items():
+            diff = opt[0] - orig_values[t][row_idx][col_idx]
             diff = round(abs(diff), 6)
-            if diff > attr[2]:
-                d1 = round(diff * attr[3], 3)
-                d2 = round(attr[2] * attr[3], 3)
-                unit = attr[5]
-                msg = f'Tile {tile_key}: diff{attr[4]}: {d1} {unit}, limit: {d2} {unit}'
-                rej_thr[tile_key] = (d1, msg, self.afss_wd_stig_orig[tile_key])
+            if diff > max_diff:
+                avg_scl = round(diff * scale, 3)
+                lim_scl = round(max_diff * scale, 3)
+                msg = f'Tile {t}: diff{label}: {avg_scl} {unit}, limit: {lim_scl} {unit}'
+                rej_thr[t] = (avg_scl, msg, orig_values[t])
 
-            diffs_passed &= diff <= attr[2]
+            diffs_passed &= diff <= max_diff
 
         return num_good_fits, rej_fits, diffs_passed, rej_thr
 
@@ -731,33 +736,44 @@ class Autofocus:
                          x_orig: float, err: float,
                          path: str
                          ):
+        """Plots AFSS series fit, original, and optimal values."""
+
+        FIG_SIZE = (12, 8)
+        FONT_SIZE = 12
+        DPI = 100
+        SCL = 1000
+
         if self.afss_mode == FOCUS:  # rescale x axis to millimetres
-            x_vals *= 10 ** 3
-            x_fit *= 10 ** 3
+            x_vals *= SCL
+            x_fit *= SCL
             if x_opt is not None:
-               x_opt *= 10 ** 3
-            x_orig *= 10 ** 3
+               x_opt *= SCL
+            x_orig *= SCL
             round_digits = 6
             unit = 'mm'
         else:
             round_digits = 3
             unit = '%'
 
+        rmse = np.round(err, decimals=4)
+
         fig, ax = plt.subplots()
-        plt.rcParams['figure.figsize'] = (12, 8)
-        plt.rcParams.update({'font.size': 12})
+        plt.rcParams['figure.figsize'] = FIG_SIZE
+        plt.rcParams.update({'font.size': FONT_SIZE})
         ax.plot(x_vals, y_vals, 'o', label='Data')
-        ax.plot(x_fit, y_fit, '-', label=f'Fit, RMSE = {np.round(err, 4)} (limit = {self.afss_rmse_limit})')
+        ax.plot(x_fit, y_fit, '-', label=f'Fit, RMSE = {rmse} (limit = {self.afss_rmse_limit})')
         ax.axvline(x_orig, color='k', linestyle=':', label=f'Previous setting: {round(x_orig, round_digits)} {unit}')
         if x_opt is not None:
-            label = f"New optimum at: {round(x_opt, round_digits)} {unit}, diff = {round(x_opt - x_orig, round_digits)} {unit}"
+            x_opt_rnd = round(x_opt, round_digits)
+            diff = round(x_opt - x_orig, round_digits)
+            label = f"New optimum at: {x_opt_rnd} {unit}, diff = {diff} {unit}"
             ax.plot(x_opt, y_opt, 'o', label=label)
         ax.legend()
         ax.set_title(str.split(os.path.basename(path), '.')[0] + '_series')
         x_labels = {FOCUS: 'Working distance [mm]', STIG_X: 'StigX [%]', STIG_Y: 'StigY [%]'}
         plt.xlabel([val for key, val in x_labels.items() if key == self.afss_mode][0])
         plt.ylabel('Sharpness [arb.u]')
-        plt.savefig(path, dpi=100)
+        plt.savefig(path, dpi=DPI)
         plt.cla()
         plt.close(fig)
 
@@ -792,7 +808,7 @@ class Autofocus:
         def_msg = ''
         wd_orig = self.afss_wd_stig_orig[tile_key][0][0]
         if tile_key not in self.afss_wd_stig_corr_optima:
-            return f'CTRL: Tile {tile_key}, fit not reliable. Original WD will be applied.'
+            return f'CTRL: Tile {tile_key}, original WD will be applied.'
 
         if cons_mode in (SPECIFIC, FOCUS_SPC_STIG_AVG):
             diff = applied_wd - wd_orig
@@ -807,7 +823,7 @@ class Autofocus:
         def_msg = ''
 
         if tile_key not in self.afss_wd_stig_corr_optima:
-            return f'CTRL: Tile {tile_key}, fit not reliable. Original {self.afss_mode} will be applied.'
+            return f'CTRL: Tile {tile_key}, original {self.afss_mode} will be applied.'
 
         if cons_mode == SPECIFIC:
             if self.afss_mode == STIG_X:
@@ -890,11 +906,8 @@ class Autofocus:
 
         cons_mode: str = (AVG, SPECIFIC, FOCUS_SPC_STIG_AVG)[self.afss_consensus_mode]
         afss_mode = self.afss_mode
+        msgs: dict = {}
 
-        if cons_mode == AVG or (cons_mode == FOCUS_SPC_STIG_AVG and afss_mode != FOCUS):
-            self.get_average_afss_correction(self.afss_filter_outliers, self.afss_weighted_averaging)
-
-        msgs = {}
         for tile_key in self.afss_wd_stig_orig:
 
             if afss_mode == FOCUS:
@@ -927,7 +940,7 @@ class Autofocus:
 
     def get_afss_factors(self):
         # Get list of WD or Stig perturbation factors to be used in automated focus/stig series
-        do_reflect = True
+        do_reflect = False
         do_duplicate = True
 
         tile_keys = self.afss_data['ref_tiles']
@@ -981,9 +994,9 @@ class Autofocus:
     def afss_set_orig_wd_stig(self):
         self.afss_current_round = 0
         for tile_key in self.afss_wd_stig_orig:
-            grid_index, tile_index = map(int, str.split(tile_key, '.'))
-            self.gm[grid_index][tile_index].wd = self.afss_wd_stig_orig[tile_key][0][0]
-            self.gm[grid_index][tile_index].stig_xy = self.afss_wd_stig_orig[tile_key][1]
+            g, t = map(int, str.split(tile_key, '.'))
+            self.gm[g][t].wd = self.afss_wd_stig_orig[tile_key][0][0]
+            self.gm[g][t].stig_xy = self.afss_wd_stig_orig[tile_key][1]
 
     def format_afss_message(self, delta_wd, delta_stig):
         progress = f'({self.afss_current_round + 1}/{self.afss_data["afss_rounds"]})'

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -15,13 +15,21 @@ intervals on selected tiles. (2) Heuristic algorithm as used in Briggman
 et al. (2011), described in Appendix A of Binding et al. (2012).
 """
 
+from copy import deepcopy
 import json
-import numpy as np
 from math import sqrt, exp, sin, cos
+from matplotlib import pyplot as plt
+import numpy as np
+import os.path
+import random
+from scipy.signal import fftconvolve
 from statistics import mean
 from time import sleep
-from scipy.signal import fftconvolve
+from typing import Tuple, Optional
+
 import autofocus_mapfost
+import utils
+from constants import *
 
 
 class Autofocus:
@@ -88,6 +96,42 @@ class Autofocus:
         self.mapfost_stig_rot = float(self.cfg['autofocus']['mapfost_astig_rotation_deg'])
         self.mapfost_stig_scale = json.loads(self.cfg['autofocus']['mapfost_astig_scaling'])
 
+        # Automated Focus/Stigmator Series
+        self.afss_wd_delta = json.loads(self.cfg['autofocus']['afss_wd_delta'])
+        self.afss_stig_x_delta = json.loads(self.cfg['autofocus']['afss_stig_x_delta'])
+        self.afss_stig_y_delta = json.loads(self.cfg['autofocus']['afss_stig_y_delta'])
+        self.afss_data = {'dwd': 0, 'dsx': 0, 'dsy': 0, 'afss_rounds': 0, 'ref_tiles': []}
+        self.afss_grid_ind: Optional[int] = None
+        self.afss_rounds = json.loads(self.cfg['autofocus']['afss_rounds'])  # Number of induced focus/stig deviations
+        self.afss_offset = json.loads(self.cfg['autofocus']['afss_offset'])  # Skip slices before first AFSS activation
+        self.afss_current_round = 0  # Position of current WD/stig deviation within AFSS series
+        self.afss_next_activation = 0  # Slice nr. of nearest planned AFSS run
+        self.afss_perturbation_series = {}  # Multiplication factors for WD/Stig deltas
+        self.afss_wd_stig_orig = {}  # Original values before the AFSS started: d = {tile_keys:[[wd, dummy=0], (sx,sy)]}
+        # dict = {tile_keys: {slice_nrs: [ (wd, dummy=0), (sx,sy), sharpness, img_full_path, stddev, [shift_vec] ]}}
+        self.afss_wd_stig_corr = {}
+        self.afss_wd_stig_corr_optima = {}  # Computed corrections AFSS: dict = {tile_keys: [wd/stig opt.val, fit_rmse]}
+        self.afss_mode = self.cfg['autofocus']['afss_mode']
+        self.afss_upcoming_mode = None
+        self.afss_consensus_mode = int(self.cfg['autofocus']['afss_consensus_mode'])
+        self.afss_drift_corrected = (self.cfg['autofocus']['afss_drift_corrected'].lower() == 'true')
+        self.afss_autostig_active = (self.cfg['autofocus']['afss_autostig_active'].lower() == 'true')
+        self.afss_active = False
+        self.afss_hyper_perturbation_series = {}
+        self.afss_shuffle = False
+        self.afss_hyper_shuffle = False
+        self.afss_filter_outliers = True
+        self.afss_weighted_averaging = True
+        self.afss_avg_corr = None
+        self.afss_max_fails = json.loads(self.cfg['autofocus']['afss_max_fails'])
+        self.afss_rmse_limit = float(self.cfg['autofocus']['afss_rmse_limit'])
+        self.afss_background_mode = (self.cfg['autofocus']['afss_background_mode'].lower() == 'true')
+        self.acquisition_running = False
+        self.afss_min_good_fits = int(self.cfg['autofocus']['min_fits'])
+        self.afss_stats = {'avg': 0, 'n_failed': 0, 'n_out_of_lim': 0, 'n_outliers': 0}
+        self.afss_min_slope = 0.5  # Slope limit for sharpness linear fit
+        self.save_reg_coll = False  # Enable/Disable saving images of registered series to stats folder
+
     def save_to_cfg(self):
         """Save current autofocus settings to ConfigParser object. Note that
         autofocus reference tiles are managed in grid_manager.
@@ -108,7 +152,20 @@ class Autofocus:
             self.heuristic_calibration)
         self.cfg['autofocus']['heuristic_rot_scale'] = str(
             [self.rot_angle, self.scale_factor])
-
+        self.cfg['autofocus']['afss_wd_delta'] = str(self.afss_wd_delta)
+        self.cfg['autofocus']['afss_stig_x_delta'] = str(self.afss_stig_x_delta)
+        self.cfg['autofocus']['afss_stig_y_delta'] = str(self.afss_stig_y_delta)
+        self.cfg['autofocus']['afss_rounds'] = str(self.afss_rounds)
+        self.cfg['autofocus']['afss_offset'] = str(self.afss_offset)
+        self.cfg['autofocus']['afss_consensus_mode'] = str(self.afss_consensus_mode)
+        self.cfg['autofocus']['afss_drift_corrected'] = str(self.afss_drift_corrected)
+        self.cfg['autofocus']['afss_autostig_active'] = str(self.afss_autostig_active)
+        self.cfg['autofocus']['afss_mode'] = str(self.afss_mode)
+        self.cfg['autofocus']['afss_max_fails'] = str(self.afss_max_fails)
+        self.cfg['autofocus']['afss_rmse_limit'] = str(self.afss_rmse_limit)
+        self.cfg['autofocus']['afss_background_mode'] = str(self.afss_background_mode)
+        self.cfg['autofocus']['min_fits'] = str(self.afss_min_good_fits)
+        
     def approximate_wd_stig_in_grid(self, grid_index):
         """Approximate the working distance and stigmation parameters for all
         non-selected active tiles in the specified grid. Simple approach for
@@ -403,3 +460,512 @@ class Autofocus:
         self.astgx_est = {}
         self.astgy_est = {}
         self.wd_stig_corr = {}
+
+
+    # ================ Methods for Automated Focus/Stigmator Series ==================
+
+    def get_average_afss_correction(self, do_filtering: bool, do_weighted_average: bool):
+        #  Function for mode='Average' in f(apply_afss_corrections)
+        valid_diffs = {}
+        m = self.afss_mode
+        dd = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
+        self.afss_stats = {'avg': 0, 'n_failed': 0, 'n_out_of_lim': 0, 'n_outliers': 0}
+
+        # Remove corrupted results from optima dict due unsuccessful fit(s)
+        d = deepcopy(self.afss_wd_stig_corr_optima)
+        for t, vals in list(d.items()):
+            rmse_val = vals[1]
+            if rmse_val == -1:
+                self.afss_stats['n_failed'] += 1
+                del d[t]
+            if rmse_val > self.afss_rmse_limit:
+                self.afss_stats['n_out_of_lim'] += 1
+                del d[t]
+
+        # Get optimal WD/Stig differences for set of valid results
+        for tile_key, vals in d.items():
+            valid_diffs[tile_key] = vals[0] - self.afss_wd_stig_orig[tile_key][dd[m][0]][dd[m][1]]
+
+        # Remove outliers from set of optimal WD/Stig differences
+        diffs = list(valid_diffs.values())
+        if do_filtering and len(diffs) > 2:
+            diffs_filtered = utils.filter_outliers(np.asarray(diffs))
+            self.afss_stats['n_outliers'] = len(diffs) - len(diffs_filtered)
+            diffs = diffs_filtered
+            # Remove filtered entries from helper dict (used in weights)
+            for k, v in list(valid_diffs.items()):
+                if v not in diffs:
+                    del (valid_diffs[k])
+
+        # Final check if amount of remaining differences is sufficient
+        if len(valid_diffs) < self.afss_min_good_fits:
+            avg = np.nan
+        # Perform weighted averaging if applicable
+        elif do_weighted_average and len(diffs) > 1:
+            # Weights for weighted average are calculated from RMSE values
+            rmse_ = [self.afss_wd_stig_corr_optima[key][1] for key in valid_diffs.keys()]
+            weights = utils.get_weights(rmse_, smallest_weight=0.3)
+            # Prevent division by zero if by any change the sum of weight is zero
+            if np.sum(weights) == 0:
+                weights[0] -= 1e-9
+            avg = np.average(diffs, weights=weights)
+        else:
+            avg = np.mean(diffs)
+
+        self.afss_avg_corr = avg
+        self.afss_stats['avg'] = avg
+
+
+    def afss_verify_results(self) -> Tuple[int, dict, bool, dict]:
+        rej_fits = {}
+        rej_thr = {}
+        diffs_passed = False
+        num_good_fits = -1
+
+        LUT = {FOCUS: (0, 0, self.max_wd_diff, 10 ** 6, 'WD', 'um'),
+               STIG_X: (1, 0, self.max_stig_x_diff, 1, 'StigX', '%'),
+               STIG_Y: (1, 1, self.max_stig_y_diff, 1, 'StigY', '%')
+               }
+
+        # Determine averaging mode
+        is_avg_mode = (self.afss_consensus_mode == 0 or (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS))
+
+        # Early return for invalid average mode
+        if is_avg_mode and self.afss_avg_corr is None:
+            return num_good_fits, rej_fits, diffs_passed, rej_thr
+
+        # Remove corrupted results from optima dict, due unsuccessful fit(s)
+        opts = self.afss_wd_stig_corr_optima
+        for t, vals in list(opts.items()):
+            rmse_val = vals[1]
+            if rmse_val > self.afss_rmse_limit or rmse_val == -1:
+                del opts[t]
+                rej_fits[t] = (rmse_val, f'Tile {t} fit rejected.')
+
+        num_good_fits = len(opts)
+        if num_good_fits == 0:
+            diffs_passed = False
+            return num_good_fits, rej_fits, diffs_passed, rej_thr
+
+        attr = LUT[self.afss_mode]
+
+        if is_avg_mode:
+            if np.isnan(self.afss_avg_corr):
+                num_good_fits = -1
+                diffs_passed = False
+            else:
+                diff = abs(self.afss_avg_corr)
+                d1 = round(self.afss_avg_corr * attr[3], 3)
+                d2 = round(attr[2] * attr[3], 3)
+                unit = attr[5]
+                msg = f'Average {attr[4]} correction: {d1} {unit} (Limit: {d2} {unit})'
+                if diff > attr[2]:  # Average diff is out of range
+                    rej_thr[list(opts.keys())[0]] = (d1, msg)
+                else:
+                    diffs_passed = True
+            return num_good_fits, rej_fits, diffs_passed, rej_thr
+
+        # Check that computed optimal WD and Stigmator values
+        # of all reference tiles are below WD/Stig thresholds
+        diffs_passed = True
+        for tile_key, opt in opts.items():
+            i1, i2 = attr[0], attr[1]
+            diff = opt[0] - self.afss_wd_stig_orig[tile_key][i1][i2]
+            diff = round(abs(diff), 6)
+            if diff > attr[2]:
+                d1 = round(diff * attr[3], 3)
+                d2 = round(attr[2] * attr[3], 3)
+                unit = attr[5]
+                msg = f'Tile {tile_key}: diff{attr[4]}: {d1} {unit}, limit: {d2} {unit}'
+                rej_thr[tile_key] = (d1, msg, self.afss_wd_stig_orig[tile_key])
+
+            diffs_passed &= diff <= attr[2]
+
+        return num_good_fits, rej_fits, diffs_passed, rej_thr
+
+
+    def afss_compute_pair_drifts(self):
+        for tile_key in self.afss_wd_stig_corr:
+            filenames = []
+            for slice_nr in self.afss_wd_stig_corr[tile_key]:
+                img_path = self.afss_wd_stig_corr[tile_key][slice_nr][3]
+                filenames.append(img_path)
+            newest_img_pair_fns = filenames[-2:]
+
+            # Cross-correlation using opencv lib
+            shift_vec = utils.compute_shifts_cv2(newest_img_pair_fns)
+            self.afss_wd_stig_corr[tile_key][slice_nr].append(shift_vec)
+
+
+    def process_afss_collections(self):
+
+        for tile_key in self.afss_wd_stig_corr:
+            fns = []
+            shifts = []
+
+            # Collect shift vectors and image filenames
+            for i, slice_nr in enumerate(self.afss_wd_stig_corr[tile_key]):
+                fns.append(self.afss_wd_stig_corr[tile_key][slice_nr][3])
+                if i != 0:  # Skip reading shift vector of first image as this was not registered to anything
+                    shifts.append(self.afss_wd_stig_corr[tile_key][slice_nr][5][0])
+
+            # Load tile-image data, align them translationally and perform cropping
+            cumm_shifts = np.cumsum(shifts, axis=0)
+            ic = utils.load_image_collection(fns)
+            ic = utils.shift_collection(ic, cumm_shifts)
+            ic = utils.crop_image_collection(ic, cumm_shifts)
+
+            # Validate image collection after cropping
+            coll_sharpness = [np.nan] * len(ic)  # Defaults to NaNs if not valid
+            if utils.validate_img_collection(ic):
+                coll_sharpness = utils.get_collection_sharpness(ic, metric='edges')
+
+                # Save sharpness plots to project stats folder
+                if self.save_reg_coll:
+                    prefix = os.path.join(self.cfg['acq']['base_dir'], 'meta', 'stats')
+                    utils.store_reg_coll(ic, fns, prefix)
+
+            # Fill the results' dict with sharpness values from drift-corrected image collection
+            for i, slice_nr in enumerate(self.afss_wd_stig_corr[tile_key]):
+                self.afss_wd_stig_corr[tile_key][slice_nr][2] = coll_sharpness[i]
+
+        return
+
+
+    def fit_afss_collections(self, plot_results=True):
+
+        def norm_data(arr: np.ndarray) -> np.ndarray:
+            arr -= np.min(arr)
+            arr /= np.max(arr)
+            return arr
+
+        m = self.afss_mode
+        rmse_lim = self.afss_rmse_limit
+        fit_slope = self.afss_min_slope
+
+        for tile_key in self.afss_wd_stig_corr:
+            tile_dict = self.afss_wd_stig_corr[tile_key]  # Values of particular tile to be processed
+            x_vals = np.asarray([], dtype=float)
+            y_vals = np.asarray([], dtype=float)
+            y_vals_std = np.asarray([], dtype=float)
+
+            # Read WD/stig_x/stig_y, sharpness values
+            d = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
+            x_orig = self.afss_wd_stig_orig[tile_key][d[m][0]][d[m][1]]  # for plotting purposes
+            for slice_nr in tile_dict:
+                x_vals = np.append(x_vals, tile_dict[slice_nr][d[m][0]][d[m][1]])  # WD, StigX or StigY series
+                y_vals = np.append(y_vals, tile_dict[slice_nr][2])  # List of sharpness values
+                y_vals_std = np.append(y_vals_std, tile_dict[slice_nr][4])  # List of 'contrast' values
+
+            # Combined sharpness metric
+            y_vals = np.sqrt(norm_data(norm_data(y_vals) ** 2 + norm_data(y_vals_std) ** 2))
+
+            # Fit sharpness values with second-order polynom or linear fit
+            x_opt, y_opt, rmse, x_fit, y_fit, fit_valid = utils.afss_fit_poly(x_vals, y_vals)
+
+            if not fit_valid:
+                x_opt, y_opt, rmse, x_fit, y_fit, fit_valid = utils.afss_fit_linear(x_vals, y_vals, fit_slope)
+
+            # Store results and proceed with plotting
+            rmse_mod = -1 if not fit_valid else rmse
+            self.afss_wd_stig_corr_optima[tile_key] = list((x_opt, rmse_mod))
+
+            # Save resulting plots into the 'meta/stats/' folder
+            if plot_results:
+                plot_path = self.generate_afss_plot_path(tile_key)
+                self.plot_afss_series(
+                    np.asarray(x_vals),
+                    np.asarray(y_vals),
+                    x_fit, y_fit, x_opt, y_opt,
+                    x_orig, rmse,
+                    plot_path
+                )
+
+        if self.afss_consensus_mode == 0 or (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS):
+            self.get_average_afss_correction(self.afss_filter_outliers, self.afss_weighted_averaging)
+
+        # Reset the correction dictionary to prepare it for next AFSS run
+        self.afss_wd_stig_corr = {}
+
+
+    def generate_afss_plot_path(self, tile_key: str) -> str:
+        # Generate plot name: basedir + 'slice_nr'_'grid_nr'_'tile_nr'_'focus/x_stig/y_stig_polyfit'.png
+        tile_dict = self.afss_wd_stig_corr[tile_key]
+        g, t = tile_key.split('.')
+        # First slice number of AFSS series
+        first_slice_nr: str = 's' + str(next(iter(tile_dict))).zfill(utils.SLICE_DIGITS)
+        tile_key_full = ('g' + str(g).zfill(utils.GRID_DIGITS) + '_' + 't' + str(t).zfill(utils.TILE_DIGITS))
+        plot_name = "_".join([first_slice_nr, tile_key_full, self.afss_mode, 'polyfit'])
+        plot_fn = os.path.join(self.cfg['acq']['base_dir'], 'meta', 'stats', plot_name + '.png')
+        return plot_fn
+
+
+    def plot_afss_series(self,
+                         x_vals: np.ndarray, y_vals: np.ndarray,
+                         x_fit: np.ndarray, y_fit: np.ndarray,
+                         x_opt: Optional[float], y_opt: Optional[float],
+                         x_orig: float, err: float,
+                         path: str
+                         ):
+        if self.afss_mode == FOCUS:  # rescale x axis to millimetres
+            x_vals *= 10 ** 3
+            x_fit *= 10 ** 3
+            if x_opt is not None:
+               x_opt *= 10 ** 3
+            x_orig *= 10 ** 3
+            round_digits = 6
+            unit = 'mm'
+        else:
+            round_digits = 3
+            unit = '%'
+
+        fig, ax = plt.subplots()
+        plt.rcParams['figure.figsize'] = (12, 8)
+        plt.rcParams.update({'font.size': 12})
+        ax.plot(x_vals, y_vals, 'o', label='Data')
+        ax.plot(x_fit, y_fit, '-', label=f'Fit, RMSE = {np.round(err, 4)} (limit = {self.afss_rmse_limit})')
+        ax.axvline(x_orig, color='k', linestyle=':', label=f'Previous setting: {round(x_orig, round_digits)} {unit}')
+        if x_opt is not None:
+            label = f"New optimum at: {round(x_opt, round_digits)} {unit}, diff = {round(x_opt - x_orig, round_digits)} {unit}"
+            ax.plot(x_opt, y_opt, 'o', label=label)
+        ax.legend()
+        ax.set_title(str.split(os.path.basename(path), '.')[0] + '_series')
+        x_labels = {FOCUS: 'Working distance [mm]', STIG_X: 'StigX [%]', STIG_Y: 'StigY [%]'}
+        plt.xlabel([val for key, val in x_labels.items() if key == self.afss_mode][0])
+        plt.ylabel('Sharpness [arb.u]')
+        plt.savefig(path, dpi=100)
+        plt.cla()
+        plt.close(fig)
+
+    @staticmethod
+    def parse_tile_key(tile_key: str) -> Tuple[int, int]:
+        """Parses tile_key into g and t, ensuring exactly two components."""
+        parts = tile_key.split('.')
+
+        # Check if there are exactly two components
+        if len(parts) != 2:
+            raise ValueError(f"Invalid tile_key format: {tile_key}. Expected format 'g.t' with exactly two parts.")
+
+        g, t = map(int, parts)
+        return g, t
+
+    def update_original_values(self, tile_key, mode):
+        """Updates original values based on background mode switch."""
+
+        if self.afss_background_mode:
+            return
+
+        g, t = self.parse_tile_key(tile_key)
+        if mode == FOCUS:
+            self.afss_wd_stig_orig[tile_key][0][0] = self.gm[g][t].wd
+        elif mode == STIG_X or mode == STIG_Y:
+            self.afss_wd_stig_orig[tile_key][1] = self.gm[g][t].stig_xy
+        return
+
+    def generate_wd_message(self, tile_key, cons_mode, applied_wd):
+        """Generates log message for the WD update."""
+
+        def_msg = ''
+        wd_orig = self.afss_wd_stig_orig[tile_key][0][0]
+        if tile_key not in self.afss_wd_stig_corr_optima:
+            return f'CTRL: Tile {tile_key}, fit not reliable. Original WD will be applied.'
+
+        if cons_mode in (SPECIFIC, FOCUS_SPC_STIG_AVG):
+            diff = applied_wd - wd_orig
+            return f'CTRL: Tile {tile_key}, delta WD = {diff * 10 ** 6:.3f} um.'
+        return def_msg
+
+    def generate_stig_message(self, tile_key, cons_mode, applied_stig_xy):
+        """Generates log message for the Stig update."""
+
+        stig_x_orig, stig_y_orig = self.afss_wd_stig_orig[tile_key][1]
+        stig_x_new, stig_y_new = applied_stig_xy
+        def_msg = ''
+
+        if tile_key not in self.afss_wd_stig_corr_optima:
+            return f'CTRL: Tile {tile_key}, fit not reliable. Original {self.afss_mode} will be applied.'
+
+        if cons_mode == SPECIFIC:
+            if self.afss_mode == STIG_X:
+                diff = stig_x_new - stig_x_orig
+                return f'CTRL: Tile {tile_key}, delta StigX = {diff:.3f} %.'
+
+            if self.afss_mode == STIG_Y:
+                diff = stig_y_new - stig_y_orig
+                return f'CTRL: Tile {tile_key}, delta StigY = {diff:.3f} %.'
+
+        return def_msg
+
+    def update_wd(self, tile_key, cons_mode):
+        """Updates WD for a given tile based on the AFSS consensus mode."""
+
+        wd_orig = self.afss_wd_stig_orig[tile_key][0][0]
+        mean_diff = self.afss_stats['avg']
+        g, t = self.parse_tile_key(tile_key)
+
+        applied_wd = wd_orig  # Defaults to original WD
+        if cons_mode == SPECIFIC and tile_key in self.afss_wd_stig_corr_optima:
+            wd_opt = self.afss_wd_stig_corr_optima[tile_key][0]
+            applied_wd = wd_opt
+        elif cons_mode in (AVG, FOCUS_SPC_STIG_AVG):
+            applied_wd = mean_diff + wd_orig
+
+        self.gm[g][t].wd = applied_wd
+
+        return applied_wd
+
+    def update_stig_x(self, tile_key, cons_mode):
+        """Updates stig values based on the mode (STIG_X)."""
+
+        stig_x_orig, stig_y_orig = self.afss_wd_stig_orig[tile_key][1]
+        mean_diff = self.afss_stats['avg']
+        g, t = self.parse_tile_key(tile_key)
+
+        applied_stig_x = stig_x_orig
+        if cons_mode == SPECIFIC and tile_key in self.afss_wd_stig_corr_optima:
+            stig_x_opt = self.afss_wd_stig_corr_optima[tile_key][0]
+            applied_stig_x = stig_x_opt
+        elif cons_mode in (AVG, FOCUS_SPC_STIG_AVG):
+            applied_stig_x = mean_diff + stig_x_orig
+
+        applied_stig_xy = (applied_stig_x, stig_y_orig)
+        self.gm[g][t].stig_xy = applied_stig_xy
+
+        return applied_stig_xy
+
+    def update_stig_y(self, tile_key, cons_mode):
+        """Updates stig values based on the mode (STIG_Y)."""
+
+        stig_x_orig, stig_y_orig = self.afss_wd_stig_orig[tile_key][1]
+        mean_diff = self.afss_stats['avg']
+        g, t = self.parse_tile_key(tile_key)
+
+        applied_stig_y = stig_y_orig
+        if cons_mode == SPECIFIC and tile_key in self.afss_wd_stig_corr_optima:
+            stig_y_opt = self.afss_wd_stig_corr_optima[tile_key][0]
+            applied_stig_y = stig_y_opt
+        elif cons_mode in (AVG, FOCUS_SPC_STIG_AVG):
+            applied_stig_y = mean_diff + stig_y_orig
+
+        applied_stig_xy = (stig_x_orig, applied_stig_y)
+        self.gm[g][t].stig_xy = applied_stig_xy
+
+        return applied_stig_xy
+
+    def update_stig_xy(self, tile_key, cons_mode, afss_mode):
+        """Updates both StigX and StigY values based on the mode."""
+        if afss_mode == STIG_X:
+            return self.update_stig_x(tile_key, cons_mode)
+        elif afss_mode == STIG_Y:
+            return self.update_stig_y(tile_key, cons_mode)
+        else:
+            raise ValueError(f"Invalid mode: {afss_mode}. Expected STIG_X or STIG_Y.")
+
+    def apply_afss_corrections(self) -> dict:
+        """Applies individual tile corrections and generate log messages."""
+
+        cons_mode: str = (AVG, SPECIFIC, FOCUS_SPC_STIG_AVG)[self.afss_consensus_mode]
+        afss_mode = self.afss_mode
+
+        if cons_mode == AVG or (cons_mode == FOCUS_SPC_STIG_AVG and afss_mode != FOCUS):
+            self.get_average_afss_correction(self.afss_filter_outliers, self.afss_weighted_averaging)
+
+        msgs = {}
+        for tile_key in self.afss_wd_stig_orig:
+
+            if afss_mode == FOCUS:
+                applied_wd = self.update_wd(tile_key, cons_mode)
+                msgs[tile_key] = self.generate_wd_message(tile_key, cons_mode, applied_wd)
+
+            elif afss_mode in [STIG_X, STIG_Y]:
+                applied_stig_xy = self.update_stig_xy(tile_key, cons_mode, afss_mode)
+                msgs[tile_key] = self.generate_stig_message(tile_key, cons_mode, applied_stig_xy)
+
+            # Update WD/STIG orig dictionary
+            self.update_original_values(tile_key, self.afss_mode)
+
+        return msgs
+
+
+    def next_afss_mode(self):
+        """
+        Returns the next AFSS mode in a cyclic sequence (focus -> stig_x -> stig_y -> focus).
+        If autostig is not active, defaults to 'FOCUS'.
+        """
+        default_mode = FOCUS
+        mode_transitions = {FOCUS: STIG_X, STIG_X: STIG_Y, STIG_Y: FOCUS}
+
+        if self.afss_autostig_active:
+            return mode_transitions.get(self.afss_mode, default_mode)
+
+        return default_mode
+
+
+    def get_afss_factors(self):
+        # Get list of WD or Stig perturbation factors to be used in automated focus/stig series
+        do_reflect = True
+        do_duplicate = True
+
+        tile_keys = self.afss_data['ref_tiles']
+
+        if self.afss_rounds == 3:
+            series = np.asarray((-1, 0, 1), dtype=float)
+            for key in tile_keys:
+                self.afss_perturbation_series[key] = series
+        else:
+            if self.afss_rounds == 4:
+                do_reflect = False
+                do_duplicate = False
+
+            series = np.linspace(-1, 1, self.afss_rounds)
+            if do_reflect:
+                new = []
+                x = series
+                for i in range(len(x)):
+                    new.append(x[i])
+                    new.append(x[::-1][i])
+                # 'Reflected' series: fcts = [-1, 1, -0.5, 0.5, 0]
+                series = np.asarray(new[:len(x)])
+            if do_duplicate:
+                new = []
+                for x in np.linspace(-1, 1, int(np.ceil(self.afss_rounds / 2))):
+                    new.append(x)
+                    new.append(x)
+                # 'Duplicated' series: fcts = [-1, -1, 0, 0, 1]
+                series = np.asarray(new[:self.afss_rounds])
+            if self.afss_shuffle:
+                # 'Shuffled' series:  fcts = [0, -0.5, 1.0, -1.0, 0.5]
+                random.shuffle(list(series))
+            if self.afss_hyper_shuffle:
+                fcts = np.tile(series, (len(tile_keys), 1))
+                for line in fcts:
+                    np.random.shuffle(line)
+                for i, key in enumerate(tile_keys):
+                    self.afss_perturbation_series[key] = fcts[i, :]
+            else:
+                for key in tile_keys:
+                    self.afss_perturbation_series[key] = series
+
+
+    def reset_afss_corrections(self):
+        self.afss_wd_stig_corr = {}
+        self.afss_wd_stig_corr_optima = {}
+        self.afss_avg_corr = None
+        self.afss_stats = {'avg': 0, 'n_failed': 0, 'n_out_of_lim': 0, 'n_outliers': 0}
+
+
+    def afss_set_orig_wd_stig(self):
+        self.afss_current_round = 0
+        for tile_key in self.afss_wd_stig_orig:
+            grid_index, tile_index = map(int, str.split(tile_key, '.'))
+            self.gm[grid_index][tile_index].wd = self.afss_wd_stig_orig[tile_key][0][0]
+            self.gm[grid_index][tile_index].stig_xy = self.afss_wd_stig_orig[tile_key][1]
+
+    def format_afss_message(self, delta_wd, delta_stig):
+        progress = f'({self.afss_current_round + 1}/{self.afss_data["afss_rounds"]})'
+        formats = {
+            FOCUS: f'Focus series active {progress}: delta WD = {delta_wd * 1e6:+.3f} um',
+            STIG_X: f'Stigmator X series active {progress}: delta StigX = {delta_stig[0]:+.2f} %',
+            STIG_Y: f'Stigmator Y series active {progress}: delta StigY = {delta_stig[1]:+.2f} %'
+        }
+        return formats.get(self.afss_mode, f'Unknown mode {self.afss_mode}')

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -107,10 +107,10 @@ class Autofocus:
         self.afss_current_round = 0  # Position of current WD/stig deviation within AFSS series
         self.afss_next_activation = 0  # Slice nr. of nearest planned AFSS run
         self.afss_perturbation_series = {}  # Multiplication factors for WD/Stig deltas
-        self.afss_wd_stig_orig = {}  # Original values before the AFSS started: d = {tile_keys:[[wd, dummy=0], (sx,sy)]}
-        # dict = {tile_keys: {slice_nrs: [ (wd, dummy=0), (sx,sy), sharpness, img_full_path, stddev, [shift_vec] ]}}
+        self.afss_wd_stig_orig = {}  # {tile_keys:[[wd, dummy_var=0], (sx,sy)]}
+        # {tile_keys: {slice_nrs: [ (wd, dummy_var=0), (sx,sy), sharpness, img_full_path, stddev, [shift_vec] ]}}
         self.afss_wd_stig_corr = {}
-        self.afss_wd_stig_corr_optima = {}  # Computed corrections AFSS: dict = {tile_keys: [wd/stig opt.val, fit_rmse]}
+        self.afss_wd_stig_corr_optima = {}  # Computed corrections AFSS: {tile_keys: [wd/stig opt.val, fit_rmse]}
         self.afss_mode = self.cfg['autofocus']['afss_mode']
         self.afss_upcoming_mode = None
         self.afss_consensus_mode = int(self.cfg['autofocus']['afss_consensus_mode'])
@@ -463,10 +463,187 @@ class Autofocus:
 
 
     # ================ Methods for Automated Focus/Stigmator Series ==================
+    # Implemented by Tomas Gancarcik, Friedrich Miescher Institute for Biomedical Research, 2025
+
+    def afss_compute_pair_shifts(self) -> None:
+        """Computes shift vectors between the last two images of each tile in the AFSS """
+        SHP_IND = 3
+        for key, tile_dict in self.afss_wd_stig_corr.items():
+
+            if not tile_dict:
+                utils.log(level='WARNING', message=f"Empty AFSS tile data for tile {key}")
+                continue
+
+            fns = []
+            slice_nrs = sorted(tile_dict.keys())[-2:]
+            for slice_nr in slice_nrs:
+                img_path = tile_dict[slice_nr][SHP_IND]
+                fns.append(img_path)
+
+            shift_vec = utils.compute_shifts_cv2(fns)
+            self.afss_wd_stig_corr[key][max(slice_nrs)].append(shift_vec)
+        return
+
+
+    def get_afss_factors(self):
+        """ Get list of WD/Stig perturbation factors to be used in focus/stig series """
+
+        do_reflect = False   # Factors are ordered as max(abs(val))
+        do_duplicate = True  # Creates doubled pert. factors instead of equidistant values
+
+        tile_keys = self.afss_data['ref_tiles']
+
+        if self.afss_rounds == 3:
+            series = np.asarray((-1, 0, 1), dtype=float)
+            for key in tile_keys:
+                self.afss_perturbation_series[key] = series
+        else:
+            if self.afss_rounds == 4:
+                do_reflect = False
+                do_duplicate = False
+
+            series = np.linspace(-1, 1, self.afss_rounds)
+            if do_reflect:
+                new = []
+                x = series
+                for i in range(len(x)):
+                    new.append(x[i])
+                    new.append(x[::-1][i])
+                # 'Reflected' series: fcts = [-1, 1, -0.5, 0.5, 0]
+                series = np.asarray(new[:len(x)])
+            if do_duplicate:
+                new = []
+                for x in np.linspace(-1, 1, int(np.ceil(self.afss_rounds / 2))):
+                    new.append(x)
+                    new.append(x)
+                # 'Duplicated' series: fcts = [-1, -1, 0, 0, 1]
+                series = np.asarray(new[:self.afss_rounds])
+            if self.afss_shuffle:
+                # 'Shuffled' series:  fcts = [0, -0.5, 1.0, -1.0, 0.5]
+                random.shuffle(list(series))
+            if self.afss_hyper_shuffle:
+                fcts = np.tile(series, (len(tile_keys), 1))
+                for line in fcts:
+                    np.random.shuffle(line)
+                for i, key in enumerate(tile_keys):
+                    self.afss_perturbation_series[key] = fcts[i, :]
+            else:
+                for key in tile_keys:
+                    self.afss_perturbation_series[key] = series
+        return
+
+    def process_afss_collections(self):
+        """Estimates sharpness of all images and all ref. tiles within an AFSS series """
+
+        for tile_key in self.afss_wd_stig_corr:
+            fns = []
+            shifts = []
+
+            # Collect shift vectors and image filenames
+            for i, slice_nr in enumerate(self.afss_wd_stig_corr[tile_key]):
+                fns.append(self.afss_wd_stig_corr[tile_key][slice_nr][3])
+                if i != 0:  # Skip reading shift vector of first image as this was not registered to anything
+                    shifts.append(self.afss_wd_stig_corr[tile_key][slice_nr][5][0])
+
+            # Load tile-image data, align them translationally and perform cropping
+            cumm_shifts = np.cumsum(shifts, axis=0)
+            ic = utils.load_image_collection(fns)
+            ic = utils.shift_collection(ic, cumm_shifts)
+            ic = utils.crop_image_collection(ic, cumm_shifts)
+
+            # Validate image collection after cropping
+            coll_sharpness = [np.nan] * len(ic)  # Defaults to NaNs if not valid
+            if utils.validate_img_collection(ic):
+                coll_sharpness = utils.get_collection_sharpness(ic, metric='edges')
+
+                # Save sharpness plots to project stats folder
+                if self.save_reg_coll:
+                    prefix = os.path.join(self.cfg['acq']['base_dir'], 'meta', 'stats')
+                    utils.store_reg_coll(ic, fns, prefix)
+
+            # Fill the results' dict with sharpness values from drift-corrected image collection
+            for i, slice_nr in enumerate(self.afss_wd_stig_corr[tile_key]):
+                self.afss_wd_stig_corr[tile_key][slice_nr][2] = coll_sharpness[i]
+        return
+
+
+    def fit_afss_collections(self, plot_results=True) -> None:
+        """ Estimates best WD/STIG of AFSS ref. tiles from sharpness data and plots results"""
+
+        AM = self.afss_mode
+        SHARPNESS_IND = 2
+        CONTRAST_IND = 4
+
+        def _norm_data(arr: np.ndarray) -> np.ndarray:
+            arr -= np.min(arr)
+            arr /= np.max(arr)
+            return arr
+
+        def _plot_afss(_tile_key, x, y, xf, yf, xopt, yopt, xo, _rmse) -> None:
+            x, y = np.asarray(x), np.asarray(y)
+            fp = self.generate_afss_plot_path(_tile_key)
+            self.plot_afss_series(x, y, xf, yf, xopt, yopt, xo, _rmse, fp)
+            return
+
+        def _fit_sharpness(x, y):
+            try:
+                # Attempt polynomial fit
+                res, valid = utils.afss_fit_poly(x, y)
+                # Fallback to linear fit (far from optimum)
+                if not valid:
+                    res, valid = utils.afss_fit_linear(x, y, self.afss_min_slope)
+                return res, valid
+
+            except Exception as e:
+                utils.log_exception(message=f"Unexpected error in sharpness fitting: {str(e)}")
+                return {}, False
+
+        for tile_key in self.afss_wd_stig_corr:
+            tile_dict = self.afss_wd_stig_corr[tile_key]  # Values of particular tile to be processed
+            if not tile_dict:
+                utils.log(level='WARNING', message=f"Empty AFSS data for tile {tile_key}")
+                continue
+
+            # Pre-allocate arrays
+            slice_nrs = list(tile_dict.keys())
+            x_vals = np.zeros(len(slice_nrs), dtype=float)
+            y_vals = np.zeros(len(slice_nrs), dtype=float)
+            y_vals_std = np.zeros(len(slice_nrs), dtype=float)
+
+            # Read-out WD/STIG_X/STIG_Y and sharpness values
+            TBL = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
+            for i, sn in enumerate(slice_nrs):
+                x_vals[i] = tile_dict[sn][TBL[AM][0]][TBL[AM][1]]  # WD, StigX or StigY series
+                y_vals[i] = tile_dict[sn][SHARPNESS_IND]           # Sharpness values
+                y_vals_std[i] = tile_dict[sn][CONTRAST_IND]        # Image 'contrast' values
+
+            # Combined sharpness metric
+            y_vals = np.sqrt(_norm_data(_norm_data(y_vals) ** 2 + _norm_data(y_vals_std) ** 2))
+
+            # Fit sharpness values with second-order polynom or linear fit
+            fit_res, fit_valid = _fit_sharpness(x_vals, y_vals)
+            x_opt, y_opt, rmse, x_fit, y_fit = fit_res
+
+            # Store results and proceed with plotting
+            rmse_mod = -1 if not fit_valid else rmse
+            self.afss_wd_stig_corr_optima[tile_key] = list((x_opt, rmse_mod))
+
+            # Save resulting plots into the 'meta/stats/' folder
+            if plot_results:
+                x_orig = self.afss_wd_stig_orig[tile_key][TBL[AM][0]][TBL[AM][1]]  # for plotting purposes
+                _plot_afss(tile_key, x_vals, y_vals, x_fit, y_fit, x_opt, y_opt, x_orig, rmse)
+
+        if self.afss_consensus_mode == 0 or (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS):
+            self.get_average_afss_correction(self.afss_filter_outliers, self.afss_weighted_averaging)
+
+        # Reset the correction dictionary to prepare it for next AFSS run
+        self.afss_wd_stig_corr = {}
+        return
 
 
     def get_average_afss_correction(self, do_filtering: bool, do_weighted_average: bool):
-        """Function for mode='Average' in f(apply_afss_corrections)"""
+        """Computes an average WD/STIG from all optimal and valid WD/STIG corrections of each ref. tiles"""
+
         valid_diffs = {}
         m = self.afss_mode
         TBL = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
@@ -514,6 +691,8 @@ class Autofocus:
 
 
     def afss_verify_results(self) -> Tuple[int, dict, bool, dict]:
+        """Analyzes AFSS series results"""
+
         rej_fits: dict = {}
         rej_thr: dict = {}
         diffs_passed: bool = False
@@ -589,134 +768,6 @@ class Autofocus:
 
         return num_good_fits, rej_fits, diffs_passed, rej_thr
 
-
-    def afss_compute_pair_shifts(self) -> None:
-        """Computes shift vectors between the last two images of each tile in the AFSS data using cross-correlation."""
-        SHP_IND = 3
-        for key, tile_dict in self.afss_wd_stig_corr.items():
-
-            if not tile_dict:
-                utils.log(level='WARNING', message=f"Empty AFSS tile data for tile {key}")
-                continue
-
-            fns = []
-            slice_nrs = sorted(tile_dict.keys())[-2:]
-            for slice_nr in slice_nrs:
-                img_path = tile_dict[slice_nr][SHP_IND]
-                fns.append(img_path)
-
-            shift_vec = utils.compute_shifts_cv2(fns)
-            self.afss_wd_stig_corr[key][max(slice_nrs)].append(shift_vec)
-        return
-
-
-    def process_afss_collections(self):
-
-        for tile_key in self.afss_wd_stig_corr:
-            fns = []
-            shifts = []
-
-            # Collect shift vectors and image filenames
-            for i, slice_nr in enumerate(self.afss_wd_stig_corr[tile_key]):
-                fns.append(self.afss_wd_stig_corr[tile_key][slice_nr][3])
-                if i != 0:  # Skip reading shift vector of first image as this was not registered to anything
-                    shifts.append(self.afss_wd_stig_corr[tile_key][slice_nr][5][0])
-
-            # Load tile-image data, align them translationally and perform cropping
-            cumm_shifts = np.cumsum(shifts, axis=0)
-            ic = utils.load_image_collection(fns)
-            ic = utils.shift_collection(ic, cumm_shifts)
-            ic = utils.crop_image_collection(ic, cumm_shifts)
-
-            # Validate image collection after cropping
-            coll_sharpness = [np.nan] * len(ic)  # Defaults to NaNs if not valid
-            if utils.validate_img_collection(ic):
-                coll_sharpness = utils.get_collection_sharpness(ic, metric='edges')
-
-                # Save sharpness plots to project stats folder
-                if self.save_reg_coll:
-                    prefix = os.path.join(self.cfg['acq']['base_dir'], 'meta', 'stats')
-                    utils.store_reg_coll(ic, fns, prefix)
-
-            # Fill the results' dict with sharpness values from drift-corrected image collection
-            for i, slice_nr in enumerate(self.afss_wd_stig_corr[tile_key]):
-                self.afss_wd_stig_corr[tile_key][slice_nr][2] = coll_sharpness[i]
-        return
-
-
-    def fit_afss_collections(self, plot_results=True) -> None:
-
-        AM = self.afss_mode
-        SHARPNESS_IND = 2
-        CONTRAST_IND = 4
-
-        def _norm_data(arr: np.ndarray) -> np.ndarray:
-            arr -= np.min(arr)
-            arr /= np.max(arr)
-            return arr
-
-        def _plot_afss(_tile_key, x, y, xf, yf, xopt, yopt, xo, _rmse) -> None:
-            x, y = np.asarray(x), np.asarray(y)
-            fp = self.generate_afss_plot_path(_tile_key)
-            self.plot_afss_series(x, y, xf, yf, xopt, yopt, xo, _rmse, fp)
-            return
-
-        def _fit_sharpness(x, y):
-            try:
-                # Attempt polynomial fit
-                res, valid = utils.afss_fit_poly(x, y)
-                # Fallback to linear fit (far from optimum)
-                if not valid:
-                    res, valid = utils.afss_fit_linear(x, y, self.afss_min_slope)
-                return res, valid
-
-            except Exception as e:
-                utils.log_exception(message=f"Unexpected error in sharpness fitting: {str(e)}")
-                return {}, False
-
-        for tile_key in self.afss_wd_stig_corr:
-            tile_dict = self.afss_wd_stig_corr[tile_key]  # Values of particular tile to be processed
-            if not tile_dict:
-                utils.log(level='WARNING', message=f"Empty AFSS data for tile {tile_key}")
-                continue
-
-            # Pre-allocate arrays
-            slice_nrs = list(tile_dict.keys())
-            x_vals = np.zeros(len(slice_nrs), dtype=float)
-            y_vals = np.zeros(len(slice_nrs), dtype=float)
-            y_vals_std = np.zeros(len(slice_nrs), dtype=float)
-
-            # Read-out WD/STIG_X/STIG_Y and sharpness values
-            TBL = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
-            for i, sn in enumerate(slice_nrs):
-                x_vals[i] = tile_dict[sn][TBL[AM][0]][TBL[AM][1]]  # WD, StigX or StigY series
-                y_vals[i] = tile_dict[sn][SHARPNESS_IND]           # Sharpness values
-                y_vals_std[i] = tile_dict[sn][CONTRAST_IND]        # Image 'contrast' values
-
-            # Combined sharpness metric
-            y_vals = np.sqrt(_norm_data(_norm_data(y_vals) ** 2 + _norm_data(y_vals_std) ** 2))
-
-            # Fit sharpness values with second-order polynom or linear fit
-            fit_res, fit_valid = _fit_sharpness(x_vals, y_vals)
-            x_opt, y_opt, rmse, x_fit, y_fit = fit_res
-
-            # Store results and proceed with plotting
-            rmse_mod = -1 if not fit_valid else rmse
-            self.afss_wd_stig_corr_optima[tile_key] = list((x_opt, rmse_mod))
-
-            # Save resulting plots into the 'meta/stats/' folder
-            if plot_results:
-                x_orig = self.afss_wd_stig_orig[tile_key][TBL[AM][0]][TBL[AM][1]]  # for plotting purposes
-                _plot_afss(tile_key, x_vals, y_vals, x_fit, y_fit, x_opt, y_opt, x_orig, rmse)
-
-        if self.afss_consensus_mode == 0 or (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS):
-            self.get_average_afss_correction(self.afss_filter_outliers, self.afss_weighted_averaging)
-
-        # Reset the correction dictionary to prepare it for next AFSS run
-        self.afss_wd_stig_corr = {}
-        return
-
-
     def generate_afss_plot_path(self, tile_key: str) -> str:
         # Generate plot name: basedir + 'slice_nr'_'grid_nr'_'tile_nr'_'focus/x_stig/y_stig_polyfit'.png
         tile_dict = self.afss_wd_stig_corr[tile_key]
@@ -755,14 +806,14 @@ class Autofocus:
             round_digits = 3
             unit = '%'
 
-        rmse = np.round(err, decimals=4)
-
         fig, ax = plt.subplots()
         plt.rcParams['figure.figsize'] = FIG_SIZE
         plt.rcParams.update({'font.size': FONT_SIZE})
         ax.plot(x_vals, y_vals, 'o', label='Data')
+        rmse = np.round(err, decimals=4)
         ax.plot(x_fit, y_fit, '-', label=f'Fit, RMSE = {rmse} (limit = {self.afss_rmse_limit})')
-        ax.axvline(x_orig, color='k', linestyle=':', label=f'Previous setting: {round(x_orig, round_digits)} {unit}')
+        prev = round(x_orig, round_digits)
+        ax.axvline(x_orig, color='k', linestyle=':', label=f'Previous setting: {prev} {unit}')
         if x_opt is not None:
             x_opt_rnd = round(x_opt, round_digits)
             diff = round(x_opt - x_orig, round_digits)
@@ -911,7 +962,6 @@ class Autofocus:
 
         return msgs
 
-
     def next_afss_mode(self):
         """
         Returns the next AFSS mode in a cyclic sequence (focus -> stig_x -> stig_y -> focus).
@@ -925,59 +975,11 @@ class Autofocus:
 
         return default_mode
 
-
-    def get_afss_factors(self):
-        # Get list of WD or Stig perturbation factors to be used in automated focus/stig series
-        do_reflect = False
-        do_duplicate = True
-
-        tile_keys = self.afss_data['ref_tiles']
-
-        if self.afss_rounds == 3:
-            series = np.asarray((-1, 0, 1), dtype=float)
-            for key in tile_keys:
-                self.afss_perturbation_series[key] = series
-        else:
-            if self.afss_rounds == 4:
-                do_reflect = False
-                do_duplicate = False
-
-            series = np.linspace(-1, 1, self.afss_rounds)
-            if do_reflect:
-                new = []
-                x = series
-                for i in range(len(x)):
-                    new.append(x[i])
-                    new.append(x[::-1][i])
-                # 'Reflected' series: fcts = [-1, 1, -0.5, 0.5, 0]
-                series = np.asarray(new[:len(x)])
-            if do_duplicate:
-                new = []
-                for x in np.linspace(-1, 1, int(np.ceil(self.afss_rounds / 2))):
-                    new.append(x)
-                    new.append(x)
-                # 'Duplicated' series: fcts = [-1, -1, 0, 0, 1]
-                series = np.asarray(new[:self.afss_rounds])
-            if self.afss_shuffle:
-                # 'Shuffled' series:  fcts = [0, -0.5, 1.0, -1.0, 0.5]
-                random.shuffle(list(series))
-            if self.afss_hyper_shuffle:
-                fcts = np.tile(series, (len(tile_keys), 1))
-                for line in fcts:
-                    np.random.shuffle(line)
-                for i, key in enumerate(tile_keys):
-                    self.afss_perturbation_series[key] = fcts[i, :]
-            else:
-                for key in tile_keys:
-                    self.afss_perturbation_series[key] = series
-
-
     def reset_afss_corrections(self):
         self.afss_wd_stig_corr = {}
         self.afss_wd_stig_corr_optima = {}
         self.afss_avg_corr = None
         self.afss_stats = {'avg': 0, 'n_failed': 0, 'n_out_of_lim': 0, 'n_outliers': 0}
-
 
     def afss_set_orig_wd_stig(self):
         self.afss_current_round = 0

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -803,15 +803,15 @@ class Autofocus:
         mean_diff = self.afss_stats['avg']
         g, t = self.parse_tile_key(tile_key)
 
-        applied_wd = wd_orig  # Defaults to original WD
-        if cons_mode == SPECIFIC and tile_key in self.afss_wd_stig_corr_optima:
+        if cons_mode in (SPECIFIC, FOCUS_SPC_STIG_AVG) and tile_key in self.afss_wd_stig_corr_optima:
             wd_opt = self.afss_wd_stig_corr_optima[tile_key][0]
             applied_wd = wd_opt
-        elif cons_mode in (AVG, FOCUS_SPC_STIG_AVG):
+        elif cons_mode in (AVG,):
             applied_wd = mean_diff + wd_orig
+        else:
+            applied_wd = wd_orig  # Defaults to original WD
 
         self.gm[g][t].wd = applied_wd
-
         return applied_wd
 
     def update_stig_x(self, tile_key, cons_mode):

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -777,25 +777,13 @@ class Autofocus:
         plt.cla()
         plt.close(fig)
 
-    @staticmethod
-    def parse_tile_key(tile_key: str) -> Tuple[int, int]:
-        """Parses tile_key into g and t, ensuring exactly two components."""
-        parts = tile_key.split('.')
-
-        # Check if there are exactly two components
-        if len(parts) != 2:
-            raise ValueError(f"Invalid tile_key format: {tile_key}. Expected format 'g.t' with exactly two parts.")
-
-        g, t = map(int, parts)
-        return g, t
-
     def update_original_values(self, tile_key, mode):
         """Updates original values based on background mode switch."""
 
         if self.afss_background_mode:
             return
 
-        g, t = self.parse_tile_key(tile_key)
+        g, t = utils.parse_tile_key(tile_key)
         if mode == FOCUS:
             self.afss_wd_stig_orig[tile_key][0][0] = self.gm[g][t].wd
         elif mode == STIG_X or mode == STIG_Y:
@@ -841,7 +829,7 @@ class Autofocus:
 
         wd_orig = self.afss_wd_stig_orig[tile_key][0][0]
         mean_diff = self.afss_stats['avg']
-        g, t = self.parse_tile_key(tile_key)
+        g, t = utils.parse_tile_key(tile_key)
 
         if cons_mode in (SPECIFIC, FOCUS_SPC_STIG_AVG) and tile_key in self.afss_wd_stig_corr_optima:
             wd_opt = self.afss_wd_stig_corr_optima[tile_key][0]
@@ -859,7 +847,7 @@ class Autofocus:
 
         stig_x_orig, stig_y_orig = self.afss_wd_stig_orig[tile_key][1]
         mean_diff = self.afss_stats['avg']
-        g, t = self.parse_tile_key(tile_key)
+        g, t = utils.parse_tile_key(tile_key)
 
         applied_stig_x = stig_x_orig
         if cons_mode == SPECIFIC and tile_key in self.afss_wd_stig_corr_optima:
@@ -878,7 +866,7 @@ class Autofocus:
 
         stig_x_orig, stig_y_orig = self.afss_wd_stig_orig[tile_key][1]
         mean_diff = self.afss_stats['avg']
-        g, t = self.parse_tile_key(tile_key)
+        g, t = utils.parse_tile_key(tile_key)
 
         applied_stig_y = stig_y_orig
         if cons_mode == SPECIFIC and tile_key in self.afss_wd_stig_corr_optima:

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -25,7 +25,7 @@ import random
 from scipy.signal import fftconvolve
 from statistics import mean
 from time import sleep
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional
 
 import autofocus_mapfost
 import utils
@@ -585,17 +585,23 @@ class Autofocus:
         return num_good_fits, rej_fits, diffs_passed, rej_thr
 
 
-    def afss_compute_pair_drifts(self) -> None:
-        for tile_key in self.afss_wd_stig_corr:
-            filenames = []
-            for slice_nr in self.afss_wd_stig_corr[tile_key]:
-                img_path = self.afss_wd_stig_corr[tile_key][slice_nr][3]
-                filenames.append(img_path)
-            newest_img_pair_fns = filenames[-2:]
+    def afss_compute_pair_shifts(self) -> None:
+        """Computes shift vectors between the last two images of each tile in the AFSS data using cross-correlation."""
+        SHP_IND = 3
+        for key, tile_dict in self.afss_wd_stig_corr.items():
 
-            # Cross-correlation using opencv lib
-            shift_vec = utils.compute_shifts_cv2(newest_img_pair_fns)
-            self.afss_wd_stig_corr[tile_key][slice_nr].append(shift_vec)
+            if not tile_dict:
+                utils.log(level='WARNING', message=f"Empty AFSS tile data for tile {key}")
+                continue
+
+            fns = []
+            slice_nrs = sorted(tile_dict.keys())[-2:]
+            for slice_nr in slice_nrs:
+                img_path = tile_dict[slice_nr][SHP_IND]
+                fns.append(img_path)
+
+            shift_vec = utils.compute_shifts_cv2(fns)
+            self.afss_wd_stig_corr[key][max(slice_nrs)].append(shift_vec)
         return
 
 

--- a/src/Autofocus.py
+++ b/src/Autofocus.py
@@ -25,7 +25,7 @@ import random
 from scipy.signal import fftconvolve
 from statistics import mean
 from time import sleep
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List
 
 import autofocus_mapfost
 import utils
@@ -464,11 +464,12 @@ class Autofocus:
 
     # ================ Methods for Automated Focus/Stigmator Series ==================
 
+
     def get_average_afss_correction(self, do_filtering: bool, do_weighted_average: bool):
-        #  Function for mode='Average' in f(apply_afss_corrections)
+        """Function for mode='Average' in f(apply_afss_corrections)"""
         valid_diffs = {}
         m = self.afss_mode
-        dd = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
+        TBL = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
         self.afss_stats = {'avg': 0, 'n_failed': 0, 'n_out_of_lim': 0, 'n_outliers': 0}
 
         # Remove corrupted results from optima dict due unsuccessful fit(s)
@@ -484,7 +485,7 @@ class Autofocus:
 
         # Get optimal WD/Stig differences for set of valid results
         for tile_key, vals in d.items():
-            valid_diffs[tile_key] = vals[0] - self.afss_wd_stig_orig[tile_key][dd[m][0]][dd[m][1]]
+            valid_diffs[tile_key] = vals[0] - self.afss_wd_stig_orig[tile_key][TBL[m][0]][TBL[m][1]]
 
         # Remove outliers from set of optimal WD/Stig differences
         diffs = list(valid_diffs.values())
@@ -524,11 +525,11 @@ class Autofocus:
 
         LUT = {FOCUS: (0, 0, self.max_wd_diff, 10 ** 6, 'WD', 'um'),
                STIG_X: (1, 0, self.max_stig_x_diff, 1, 'StigX', '%'),
-               STIG_Y: (1, 1, self.max_stig_y_diff, 1, 'StigY', '%')
-               }
+               STIG_Y: (1, 1, self.max_stig_y_diff, 1, 'StigY', '%')}
 
         # Determine averaging mode
-        is_avg_mode = (self.afss_consensus_mode == 0 or (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS))
+        is_avg_mode = (self.afss_consensus_mode == 0 or
+                       (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS))
 
         # Early return for invalid average mode
         if is_avg_mode and self.afss_avg_corr is None:
@@ -584,7 +585,7 @@ class Autofocus:
         return num_good_fits, rej_fits, diffs_passed, rej_thr
 
 
-    def afss_compute_pair_drifts(self):
+    def afss_compute_pair_drifts(self) -> None:
         for tile_key in self.afss_wd_stig_corr:
             filenames = []
             for slice_nr in self.afss_wd_stig_corr[tile_key]:
@@ -595,6 +596,7 @@ class Autofocus:
             # Cross-correlation using opencv lib
             shift_vec = utils.compute_shifts_cv2(newest_img_pair_fns)
             self.afss_wd_stig_corr[tile_key][slice_nr].append(shift_vec)
+        return
 
 
     def process_afss_collections(self):
@@ -628,43 +630,64 @@ class Autofocus:
             # Fill the results' dict with sharpness values from drift-corrected image collection
             for i, slice_nr in enumerate(self.afss_wd_stig_corr[tile_key]):
                 self.afss_wd_stig_corr[tile_key][slice_nr][2] = coll_sharpness[i]
-
         return
 
 
-    def fit_afss_collections(self, plot_results=True):
+    def fit_afss_collections(self, plot_results=True) -> None:
 
-        def norm_data(arr: np.ndarray) -> np.ndarray:
+        AM = self.afss_mode
+        SHARPNESS_IND = 2
+        CONTRAST_IND = 4
+
+        def _norm_data(arr: np.ndarray) -> np.ndarray:
             arr -= np.min(arr)
             arr /= np.max(arr)
             return arr
 
-        m = self.afss_mode
-        rmse_lim = self.afss_rmse_limit
-        fit_slope = self.afss_min_slope
+        def _plot_afss(_tile_key, x, y, xf, yf, xopt, yopt, xo, _rmse) -> None:
+            x, y = np.asarray(x), np.asarray(y)
+            fp = self.generate_afss_plot_path(_tile_key)
+            self.plot_afss_series(x, y, xf, yf, xopt, yopt, xo, _rmse, fp)
+            return
+
+        def _fit_sharpness(x, y):
+            try:
+                # Attempt polynomial fit
+                res, valid = utils.afss_fit_poly(x, y)
+                # Fallback to linear fit (far from optimum)
+                if not valid:
+                    res, valid = utils.afss_fit_linear(x, y, self.afss_min_slope)
+                return res, valid
+
+            except Exception as e:
+                utils.log_exception(message=f"Unexpected error in sharpness fitting: {str(e)}")
+                return {}, False
 
         for tile_key in self.afss_wd_stig_corr:
             tile_dict = self.afss_wd_stig_corr[tile_key]  # Values of particular tile to be processed
-            x_vals = np.asarray([], dtype=float)
-            y_vals = np.asarray([], dtype=float)
-            y_vals_std = np.asarray([], dtype=float)
+            if not tile_dict:
+                utils.log(level='WARNING', message=f"Empty AFSS data for tile {tile_key}")
+                continue
 
-            # Read WD/stig_x/stig_y, sharpness values
-            d = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
-            x_orig = self.afss_wd_stig_orig[tile_key][d[m][0]][d[m][1]]  # for plotting purposes
-            for slice_nr in tile_dict:
-                x_vals = np.append(x_vals, tile_dict[slice_nr][d[m][0]][d[m][1]])  # WD, StigX or StigY series
-                y_vals = np.append(y_vals, tile_dict[slice_nr][2])  # List of sharpness values
-                y_vals_std = np.append(y_vals_std, tile_dict[slice_nr][4])  # List of 'contrast' values
+            # Pre-allocate arrays
+            slice_nrs = list(tile_dict.keys())
+            x_vals = np.zeros(len(slice_nrs), dtype=float)
+            y_vals = np.zeros(len(slice_nrs), dtype=float)
+            y_vals_std = np.zeros(len(slice_nrs), dtype=float)
+
+            # Read-out WD/STIG_X/STIG_Y and sharpness values
+            TBL = {FOCUS: (0, 0), STIG_X: (1, 0), STIG_Y: (1, 1)}
+            for i, sn in enumerate(slice_nrs):
+                x_vals[i] = tile_dict[sn][TBL[AM][0]][TBL[AM][1]]  # WD, StigX or StigY series
+                y_vals[i] = tile_dict[sn][SHARPNESS_IND]           # Sharpness values
+                y_vals_std[i] = tile_dict[sn][CONTRAST_IND]        # Image 'contrast' values
 
             # Combined sharpness metric
-            y_vals = np.sqrt(norm_data(norm_data(y_vals) ** 2 + norm_data(y_vals_std) ** 2))
+            y_vals = np.sqrt(_norm_data(_norm_data(y_vals) ** 2 + _norm_data(y_vals_std) ** 2))
 
             # Fit sharpness values with second-order polynom or linear fit
-            x_opt, y_opt, rmse, x_fit, y_fit, fit_valid = utils.afss_fit_poly(x_vals, y_vals)
-
-            if not fit_valid:
-                x_opt, y_opt, rmse, x_fit, y_fit, fit_valid = utils.afss_fit_linear(x_vals, y_vals, fit_slope)
+            fit_res, fit_valid = _fit_sharpness(x_vals, y_vals)
+            x_opt, y_opt, rmse, x_fit, y_fit = fit_res
 
             # Store results and proceed with plotting
             rmse_mod = -1 if not fit_valid else rmse
@@ -672,20 +695,15 @@ class Autofocus:
 
             # Save resulting plots into the 'meta/stats/' folder
             if plot_results:
-                plot_path = self.generate_afss_plot_path(tile_key)
-                self.plot_afss_series(
-                    np.asarray(x_vals),
-                    np.asarray(y_vals),
-                    x_fit, y_fit, x_opt, y_opt,
-                    x_orig, rmse,
-                    plot_path
-                )
+                x_orig = self.afss_wd_stig_orig[tile_key][TBL[AM][0]][TBL[AM][1]]  # for plotting purposes
+                _plot_afss(tile_key, x_vals, y_vals, x_fit, y_fit, x_opt, y_opt, x_orig, rmse)
 
         if self.afss_consensus_mode == 0 or (self.afss_consensus_mode == 2 and self.afss_mode != FOCUS):
             self.get_average_afss_correction(self.afss_filter_outliers, self.afss_weighted_averaging)
 
         # Reset the correction dictionary to prepare it for next AFSS run
         self.afss_wd_stig_corr = {}
+        return
 
 
     def generate_afss_plot_path(self, tile_key: str) -> str:

--- a/src/Grid.py
+++ b/src/Grid.py
@@ -519,6 +519,11 @@ class Grid(list):
         for tile in self:
             tile.wd = wd
 
+    def set_delta_wd_for_all_tiles(self, dwd):
+        """Shift working distance by dwd for all tiles in the grid."""
+        for tile in self.__tiles:
+            tile.wd += dwd
+
     def set_wd_stig_xy_for_uninitialized_tiles(self, wd, stig_xy):
         """Set all tiles that are uninitialized to specified working
         distance and stig_xy."""

--- a/src/GridManager.py
+++ b/src/GridManager.py
@@ -33,6 +33,8 @@ import utils
 from Grid import Grid
 from image_io import imread
 
+from constants import tile_sizes
+
 
 class GridManager(list):
 
@@ -172,6 +174,10 @@ class GridManager(list):
         array_path = grids_data.get('array_file')
         self.array_data = ArrayData.ArrayData(array_path)
         self.magc_mode = (self.cfg['sys']['magc_mode'].lower() == 'true')
+        
+        # Available image sizes at ZEISS Gemini SEM and Merlin SEM used for AFSS binary masks
+        self.tile_sizes = tile_sizes
+
 
     def get_grid_label(self, grid_index):
         if grid_index is not None:

--- a/src/ImageInspector.py
+++ b/src/ImageInspector.py
@@ -35,9 +35,12 @@ class ImageInspector:
         self.gm = grid_manager
         self.tile_means = {}
         self.tile_stddevs = {}
+        self.tile_sharpnesses = {}
         self.tile_reslice_line = {}
+        self.tile_stats = {}
         self.ov_means = {}
         self.ov_stddevs = {}
+        self.ov_sharpnesses = {}
         self.ov_images = {}
         self.ov_reslice_line = {}
         self.prev_img_mean_stddev = [0, 0]
@@ -79,6 +82,7 @@ class ImageInspector:
             self.cfg['debris']['histogram_diff_threshold'])
 
         self.magc_mode = (self.cfg['sys']['magc_mode'].lower() == 'true')
+        self.afss_drift_corr = (self.cfg['autofocus']['afss_drift_corrected'].lower() == 'true')
 
     def save_to_cfg(self):
         """Save all parameters managed by image_inspector to config."""
@@ -116,7 +120,7 @@ class ImageInspector:
         mean and stddev, and check if image appears incomplete.
         """
         img = None
-        mean, stddev = 0, 0
+        mean, stddev, sharpness = 0, 0, 0
         load_error = False
         load_exception = ''
         grab_incomplete = False
@@ -134,6 +138,8 @@ class ImageInspector:
             # Calculate mean and stddev
             mean = np.mean(img)
             stddev = np.std(img)
+            # sharpness = np.mean(utils.grad_img(img))
+            sharpness = 0
 
             # Was complete image grabbed? Test if first or final line of image
             # is black/white/uniform greyscale
@@ -143,17 +149,24 @@ class ImageInspector:
             grab_incomplete = (np.min(first_line) == np.max(first_line) or
                                np.min(final_line) == np.max(final_line))
 
-        return img, mean, stddev, load_error, load_exception, grab_incomplete
+        return img, mean, stddev, sharpness, load_error, load_exception, grab_incomplete
 
-    def process_tile(self, filename, grid_index, tile_index, slice_counter):
+    def process_tile(self, filename, grid_index, tile_index, slice_counter, mask, masking):
         range_test_passed, slice_by_slice_test_passed = False, False
         frozen_frame_error = False
         tile_selected = False
+        ma_mean, ma_stddev, ma_sharp = 0, 0, 0
 
         # process_mem_in_use_gb = psutil.Process().memory_info().rss / 1024 / 1024 / 1024
 
-        img, mean, stddev, load_error, load_exception, grab_incomplete = (
+        img, mean, stddev, sharpness, load_error, load_exception, grab_incomplete = (
             self.load_and_inspect(filename))
+
+        # Compute masked stats only if masking is active and drift correction is not
+        if masking and not self.afss_drift_corr:
+            # Modify following condition if sharpness should be computed for all active tiles
+            if tile_index in self.gm[grid_index].autofocus_ref_tiles():
+                ma_mean, ma_stddev, ma_sharp, err, ex = self.load_and_inspect_image_quality(filename, mask)
 
         if not load_error:
 
@@ -200,6 +213,21 @@ class ImageInspector:
                 self.tile_stddevs[tile_key].pop(0)
             self.tile_stddevs[tile_key].append((slice_counter, stddev))
 
+            if tile_key not in self.tile_sharpnesses:
+                self.tile_sharpnesses[tile_key] = []
+            if len(self.tile_sharpnesses[tile_key]) > 1:
+                self.tile_sharpnesses[tile_key].pop(0)
+            self.tile_sharpnesses[tile_key].append((slice_counter, sharpness))
+
+            if tile_key not in self.tile_stats:
+                self.tile_stats[tile_key] = []
+            if len(self.tile_stats[tile_key]) > 1:
+                self.tile_stats[tile_key].pop(0)
+            self.tile_stats[tile_key].append((slice_counter,
+                                              ma_mean,
+                                              ma_stddev,
+                                              ma_sharp))
+                                              
             if (tile_key_short in self.monitoring_tile_list
                 or 'all' in self.monitoring_tile_list):
                 if len(self.tile_means[tile_key]) > 1:
@@ -231,9 +259,39 @@ class ImageInspector:
 
             del preview_img
 
-        return (img, mean, stddev,
+        if masking:
+            sharpness = ma_sharp
+        return (img, mean, stddev, sharpness,
                 range_test_passed, slice_by_slice_test_passed, tile_selected,
                 load_error, load_exception, grab_incomplete, frozen_frame_error)
+
+    @staticmethod
+    def load_and_inspect_image_quality(filename, mask):
+        """Load filename with error handling and calculate image statistics
+         on centered circular region of the image.
+        """
+        img = None
+        ma_mean, ma_stddev, ma_sharp = 0, 0, 0
+        load_error = False
+        load_exception = ''
+        try:
+            img = imread(filename)
+        except Exception as e:
+            load_exception = str(e)
+            load_error = True
+        if not load_error:
+            # Apply circular binary mask on original image
+            img = np.ma.array(img, mask=mask)
+
+            # Apply circular binary mask on gradient image
+            img_grad = np.ma.array(utils.grad_img(img), mask=mask)
+            
+            # Calculate mean, stddev, sharpness on center circular region of image
+            # ma_mean = img.mean() # not used
+            # ma_stddev = img.std() # not used
+            ma_sharp = img_grad.mean()
+            
+        return ma_mean, ma_stddev, ma_sharp, load_error, load_exception
 
     def save_tile_stats(self, base_dir, grid_index, tile_index, slice_counter):
         """Write mean and SD of specified tile to disk."""
@@ -292,7 +350,7 @@ class ImageInspector:
         """Load overview image from disk and perform standard tests."""
         range_test_passed = False
 
-        ov_img, mean, stddev, load_error, load_exception, grab_incomplete = (
+        ov_img, mean, stddev, sharpness, load_error, load_exception, grab_incomplete = (
             self.load_and_inspect(filename))
 
         if not load_error:
@@ -317,6 +375,12 @@ class ImageInspector:
                 self.ov_stddevs[ov_index].pop(0)
             self.ov_stddevs[ov_index].append(stddev)
 
+            if not (ov_index in self.ov_sharpnesses):
+                self.ov_sharpnesses[ov_index] = []
+            if len(self.ov_sharpnesses[ov_index]) > 1:
+                self.ov_sharpnesses[ov_index].pop(0)
+            self.ov_sharpnesses[ov_index].append(sharpness)
+            
             # Save reslice line in memory. Take a 400-px line from the centre
             # of the image. This works for all frame resolutions.
             # Only saved to disk later if OV accepted.
@@ -330,7 +394,7 @@ class ImageInspector:
                 (self.mean_lower_limit <= mean <= self.mean_upper_limit) and
                 (self.stddev_lower_limit <= stddev <= self.stddev_upper_limit))
 
-        return (ov_img, mean, stddev,
+        return (ov_img, mean, stddev, sharpness,
                 range_test_passed, load_error, load_exception, grab_incomplete)
 
     def save_ov_stats(self, base_dir, ov_index, slice_counter):
@@ -346,7 +410,9 @@ class ImageInspector:
                 with open(stats_filename, 'a') as file:
                     file.write(str(slice_counter) + ';'
                                + str(self.ov_means[ov_index][-1]) + ';'
-                               + str(self.ov_stddevs[ov_index][-1]) + '\n')
+                               + str(self.ov_stddevs[ov_index][-1]) + ';'
+                               + str(self.ov_sharpnesses[ov_index][-1])
+                               + '\n')
             except Exception as e:
                 success = False  # couldn't write to disk
                 error_msg = str(e)
@@ -506,4 +572,5 @@ class ImageInspector:
         self.tile_means = {}
         self.tile_stddevs = {}
         self.tile_reslice_line = {}
+        self.tile_sharpnesses = {}
         self.prev_img_mean_stddev = [0, 0]

--- a/src/ImageInspector.py
+++ b/src/ImageInspector.py
@@ -138,8 +138,6 @@ class ImageInspector:
             # Calculate mean and stddev
             mean = np.mean(img)
             stddev = np.std(img)
-            # sharpness = np.mean(utils.grad_img(img))
-            sharpness = 0
 
             # Was complete image grabbed? Test if first or final line of image
             # is black/white/uniform greyscale
@@ -163,10 +161,10 @@ class ImageInspector:
             self.load_and_inspect(filename))
 
         # Compute masked stats only if masking is active and drift correction is not
-        if masking and not self.afss_drift_corr:
+        if not load_error and not self.afss_drift_corr and masking:
             # Modify following condition if sharpness should be computed for all active tiles
             if tile_index in self.gm[grid_index].autofocus_ref_tiles():
-                ma_mean, ma_stddev, ma_sharp, err, ex = self.load_and_inspect_image_quality(filename, mask)
+                ma_mean, ma_stddev, ma_sharp = utils.inspect_masked_img(img, mask)
 
         if not load_error:
 
@@ -264,34 +262,6 @@ class ImageInspector:
         return (img, mean, stddev, sharpness,
                 range_test_passed, slice_by_slice_test_passed, tile_selected,
                 load_error, load_exception, grab_incomplete, frozen_frame_error)
-
-    @staticmethod
-    def load_and_inspect_image_quality(filename, mask):
-        """Load filename with error handling and calculate image statistics
-         on centered circular region of the image.
-        """
-        img = None
-        ma_mean, ma_stddev, ma_sharp = 0, 0, 0
-        load_error = False
-        load_exception = ''
-        try:
-            img = imread(filename)
-        except Exception as e:
-            load_exception = str(e)
-            load_error = True
-        if not load_error:
-            # Apply circular binary mask on original image
-            img = np.ma.array(img, mask=mask)
-
-            # Apply circular binary mask on gradient image
-            img_grad = np.ma.array(utils.grad_img(img), mask=mask)
-            
-            # Calculate mean, stddev, sharpness on center circular region of image
-            # ma_mean = img.mean() # not used
-            # ma_stddev = img.std() # not used
-            ma_sharp = img_grad.mean()
-            
-        return ma_mean, ma_stddev, ma_sharp, load_error, load_exception
 
     def save_tile_stats(self, base_dir, grid_index, tile_index, slice_counter):
         """Write mean and SD of specified tile to disk."""

--- a/src/MainControls.py
+++ b/src/MainControls.py
@@ -1759,7 +1759,7 @@ class MainControls(QMainWindow):
         dialog.exec()
 
     def open_autofocus_settings_dlg(self):
-        dialog = AutofocusSettingsDlg(self.sem, self.autofocus, self.gm)
+        dialog = AutofocusSettingsDlg(self.sem, self.autofocus, self.gm, self.img_inspector)
         if dialog.exec():
             if self.autofocus.method == 2:
                 self.checkBox_useAutofocus.setText('Focus tracking')

--- a/src/Viewport.py
+++ b/src/Viewport.py
@@ -2043,7 +2043,7 @@ class Viewport(QWidget):
                     show_autofocus_label = (
                         grid[tile_index].autofocus_active
                         and self.acq.use_autofocus
-                        and (self.autofocus.method < 2 or self.autofocus.method == 3))
+                        and self.autofocus.method in (0, 1, 3, 4))
                     show_tracking_label = (
                         grid[tile_index].autofocus_active
                         and self.acq.use_autofocus

--- a/src/config_template.py
+++ b/src/config_template.py
@@ -19,18 +19,24 @@ import os
 from configparser import ConfigParser
 
 
+# Always points to the folder where this .py file lives
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 # The following constants must be updated if entries are added to or
 # deleted from the default configuration files
-CFG_TEMPLATE_FILE = 'src/default_cfg/default.ini'    # Template of session configuration
+#CFG_TEMPLATE_FILE = 'src/default_cfg/default.ini'    # Template of session configuration
+CFG_TEMPLATE_FILE = os.path.join(BASE_DIR, "default_cfg", "default.ini")
 CFG_NUMBER_SECTIONS = 12
-CFG_NUMBER_KEYS = 231
+CFG_NUMBER_KEYS = 259
 
-SYSCFG_TEMPLATE_FILE = 'src/default_cfg/system.cfg'  # Template of system configuration
+#SYSCFG_TEMPLATE_FILE = 'src/default_cfg/system.cfg'  # Template of system configuration
+SYSCFG_TEMPLATE_FILE = os.path.join(BASE_DIR, "default_cfg", "system.cfg")
 SYSCFG_NUMBER_SECTIONS = 8
-SYSCFG_NUMBER_KEYS = 55
+SYSCFG_NUMBER_KEYS = 57
 
 # Presets file: contains presets for different devices
-DEVICE_PRESETS_FILE = 'src/default_cfg/device_presets.cfg'
+#DEVICE_PRESETS_FILE = 'src/default_cfg/device_presets.cfg'
+DEVICE_PRESETS_FILE = os.path.join(BASE_DIR, "default_cfg", "device_presets.cfg")
 
 # Backward compatibility for older system config files
 LEGACY_DEVICE_NUMBERS = {0: 'Gatan 3View',
@@ -60,10 +66,9 @@ def process_cfg(current_cfg, current_syscfg, is_default_cfg=False):
     exceptions = ''
 
     if is_default_cfg:
-        pass
         # Currently, the only validity check is verifying the number of entries.
-        #cfg_valid = check_number_of_entries(current_cfg, False)
-        #syscfg_valid = check_number_of_entries(current_syscfg, True)
+        cfg_valid = check_number_of_entries(current_cfg, False)
+        syscfg_valid = check_number_of_entries(current_syscfg, True)
     else:
         # Load default configuration. This file must be up-to-date. It is always
         # bundled with each new version of SBEMimage.
@@ -81,10 +86,10 @@ def process_cfg(current_cfg, current_syscfg, is_default_cfg=False):
         except Exception as e:
             syscfg_load_success = False
             exceptions += str(e) + '; '
-        #if cfg_load_success:
-        #    cfg_valid = check_number_of_entries(cfg_template, False)
-        #if syscfg_load_success:
-        #    syscfg_valid = check_number_of_entries(syscfg_template, True)
+        if cfg_load_success:
+           cfg_valid = check_number_of_entries(cfg_template, False)
+        if syscfg_load_success:
+           syscfg_valid = check_number_of_entries(syscfg_template, True)
 
         if (cfg_load_success and syscfg_load_success
                 and cfg_valid and syscfg_valid):

--- a/src/constants.py
+++ b/src/constants.py
@@ -100,6 +100,8 @@ AVG = 'Average'
 SPECIFIC = 'tile_specific'
 FOCUS_SPC_STIG_AVG = 'focus_specific_stig_average'
 
+AFSS_LABELS = {FOCUS: 'Focus', STIG_X: 'Stigmator X', STIG_Y: 'Stigmator Y'}
+
 # Available image sizes at ZEISS Gemini SEM and Merlin SEM
 tile_sizes = {'mask_8k': (8192, 6144),
               'mask_6k': (6144, 4608),

--- a/src/constants.py
+++ b/src/constants.py
@@ -92,6 +92,22 @@ LOG_FORMAT_DATETIME = '%Y-%m-%d %H:%M:%S'
 LOG_MAX_FILESIZE = 10000000
 LOG_MAX_FILECOUNT = 20
 
+# Constants for Automated Focus Stigmator Series
+FOCUS = 'focus'
+STIG_X = 'stig_x'
+STIG_Y = 'stig_y'
+AVG = 'Average'
+SPECIFIC = 'tile_specific'
+FOCUS_SPC_STIG_AVG = 'focus_specific_stig_average'
+
+# Available image sizes at ZEISS Gemini SEM and Merlin SEM
+tile_sizes = {'mask_8k': (8192, 6144),
+              'mask_6k': (6144, 4608),
+              'mask_4k': (4096, 3072),
+              'mask_3k': (3072, 2304),
+              'mask_2k': (2048, 1536),
+              'mask_1k': (1024, 768),
+              'mask_0k': (512, 384)}
 
 # TODO: replace values with auto()
 class Error(Enum):
@@ -152,6 +168,7 @@ class Error(Enum):
     autofocus_heuristic = 506
     wd_stig_difference = 507
     metadata_server = 508
+    autofocus_afss = 509
 
     # Reserved for user-defined errors
     test_case = 601
@@ -227,7 +244,8 @@ Errors = {
     Error.autofocus_heuristic: 'Autofocus error (heuristic)',
     Error.wd_stig_difference: 'WD/STIG difference error',
     Error.metadata_server: 'Metadata server error',
-
+    Error.autofocus_afss: 'Autofocus error (AFSS)',
+    
     # Reserved for user-defined errors
     Error.test_case: 'Test case error',
 

--- a/src/default_cfg/default.ini
+++ b/src/default_cfg/default.ini
@@ -518,4 +518,29 @@ mapfost_dwell_time = 0.8
 mapfost_convergence_threshold_um = 0.2
 # the bool switch which flags the expectation of large aberrations (>20 um) in the first few iterations.
 mapfost_large_aberrations = 0
-
+# Absolute value of maximal WD deviation applied during Automated Focus series [-800 nm:+800 nm]
+afss_wd_delta = 800e-9
+# Absolute value of maximal StigX deviation applied during Automated StigX series
+afss_stig_x_delta = 0.2
+# Absolute value of maximal StigY deviation applied during Automated StigY series
+afss_stig_y_delta = 0.2
+# Number of WD/Stig deviations to be applied during Automated Focus/Stig series
+afss_rounds = 6
+# Number of slices to be done before the AFSS series activation (after Start/Restart of acquisition)
+afss_offset = 0
+# 0: 'Average' over results from all tracked tile or 1: 'Tile specific' for no averaging
+afss_consensus_mode = 1
+# Activation/deactivation of drift correction to the images of AFSS series
+afss_drift_corrected = 1
+# Activation/deactivation of both auto-stigmator routines
+afss_autostig_active = True
+# Current AFSS mode; one of: focus, stig_x, stig_y
+afss_mode = focus
+# Maximum number of failed AFSS runs (for each type - Focs/StigX/StigY)
+afss_max_fails = 3
+# Root-mean square error limit of measured sharpness with respect to fitted quadratic curve
+afss_rmse_limit = 0.25
+# If background mode is set to True, AFSS results won't be applied
+afss_background_mode = False
+# Minimum amount of values to be used for new WD/Stig setting average
+min_fits = 3

--- a/src/default_cfg/default.ini
+++ b/src/default_cfg/default.ini
@@ -519,13 +519,13 @@ mapfost_convergence_threshold_um = 0.2
 # the bool switch which flags the expectation of large aberrations (>20 um) in the first few iterations.
 mapfost_large_aberrations = 0
 # Absolute value of maximal WD deviation applied during Automated Focus series [-800 nm:+800 nm]
-afss_wd_delta = 800e-9
+afss_wd_delta = 1500e-9
 # Absolute value of maximal StigX deviation applied during Automated StigX series
 afss_stig_x_delta = 0.2
 # Absolute value of maximal StigY deviation applied during Automated StigY series
 afss_stig_y_delta = 0.2
 # Number of WD/Stig deviations to be applied during Automated Focus/Stig series
-afss_rounds = 6
+afss_rounds = 3
 # Number of slices to be done before the AFSS series activation (after Start/Restart of acquisition)
 afss_offset = 0
 # 0: 'Average' over results from all tracked tile or 1: 'Tile specific' for no averaging

--- a/src/dialog/AutofocusSettingsDlg.py
+++ b/src/dialog/AutofocusSettingsDlg.py
@@ -9,13 +9,14 @@ from dialog.AutofocusZEISSParamsDlg import AutofocusZEISSParamsDlg
 
 class AutofocusSettingsDlg(QDialog):
     """Dialog to adjust settings for the SEM autofocus, the heuristic autofocus,
-    MAPFoSt, and for tracking the focus/stig when refocusing manually.
+    MAPFoSt, AFSS and for tracking the focus/stig when refocusing manually.
     """
-    def __init__(self, sem, autofocus, grid_manager):
+    def __init__(self, sem, autofocus, grid_manager, image_inspector):
         super().__init__()
         self.sem = sem
         self.autofocus = autofocus
         self.gm = grid_manager
+        self.img_inspector = image_inspector
         loadUi('gui/autofocus_settings_dlg.ui', self)
         self.setWindowModality(Qt.ApplicationModal)
         self.setWindowIcon(utils.get_window_icon())
@@ -29,6 +30,8 @@ class AutofocusSettingsDlg(QDialog):
             self.radioButton_useTrackingOnly.setChecked(True)
         elif self.autofocus.method == 3:
             self.radioButton_useMAPFoSt.setChecked(True)
+        elif self.autofocus.method == 4:
+            self.radioButton_useAFSS.setChecked(True)
         self.radioButton_useSEM.toggled.connect(self.group_box_update)
         self.radioButton_useHeuristic.toggled.connect(self.group_box_update)
         self.radioButton_useTrackingOnly.toggled.connect(self.group_box_update)
@@ -89,16 +92,76 @@ class AutofocusSettingsDlg(QDialog):
             self.autofocus.heuristic_calibration[2])
         self.doubleSpinBox_stigRot.setValue(self.autofocus.rot_angle)
         self.doubleSpinBox_stigScale.setValue(self.autofocus.scale_factor)
-
+        # Automated Focus/Stigmator Series:
+        self.spinBox_afss_interval.setValue(self.autofocus.interval)  # shared with SEM autofocus
+        self.spinBox_afss_offset.setValue(self.autofocus.afss_offset)
+        self.doubleSpinBox_afss_wdDiff.setValue(self.autofocus.afss_wd_delta * 1000000)
+        self.doubleSpinBox_afss_stigXDiff.setValue(self.autofocus.afss_stig_x_delta)
+        self.doubleSpinBox_afss_stigYDiff.setValue(self.autofocus.afss_stig_y_delta)
+        self.spinBox_afss_rounds.setValue(self.autofocus.afss_rounds)
+        cons_modes = ['Average', 'Specific', 'Specific: Focus, Average: Stig']
+        self.comboBox_afss_consensus_mode.addItems(cons_modes)
+        self.comboBox_afss_consensus_mode.setCurrentIndex(self.autofocus.afss_consensus_mode)
+        self.checkBox_afss_drift_corrected.setChecked(self.autofocus.afss_drift_corrected)
+        self.checkBox_afss_autostig_active.setChecked(self.autofocus.afss_autostig_active)
+        self.spinBox_afss_fails.setValue(self.autofocus.afss_max_fails)
+        self.doubleSpinBox_afss_rmse_limit.setValue(self.autofocus.afss_rmse_limit)
+        self.checkBox_afss_background_mode.setChecked(self.autofocus.afss_background_mode)
+        self.mode_keys = ('focus', 'stig_x', 'stig_y')
+        self.mode_vals = ('AutoFocus', 'AutoStigX', 'AutoStigY')
+        self.afss_modes = dict(zip(self.mode_keys, self.mode_vals))
+        self.comboBox_afss_mode.addItems(list(self.mode_vals))
+        self.comboBox_afss_mode.setCurrentIndex(self.mode_keys.index(self.autofocus.afss_mode))
+        self.comboBox_afss_upcoming_mode.addItems(list(self.mode_vals))
+        # Resolve upcoming AFSS mode
+        if self.autofocus.afss_upcoming_mode is None:
+            self.autofocus.afss_upcoming_mode = self.autofocus.next_afss_mode()
+        if not self.autofocus.acquisition_running:
+            self.comboBox_afss_upcoming_mode.setCurrentIndex(self.mode_keys.index(self.autofocus.afss_upcoming_mode))
+        # Disable AFSS setters if AutoStigmator is disabled
+        if not self.autofocus.afss_autostig_active:
+            self.comboBox_afss_mode.setEnabled(False)
+            self.comboBox_afss_upcoming_mode.setEnabled(False)
+        # Ensure correct AFSS setters when acquisition is running
+        if self.autofocus.acquisition_running:
+            self.comboBox_afss_mode.setEnabled(False)
+            if self.autofocus.afss_autostig_active:
+                self.comboBox_afss_upcoming_mode.setEnabled(True)
+                up_ind = self.mode_keys.index(self.autofocus.afss_upcoming_mode)
+                self.comboBox_afss_upcoming_mode.setCurrentIndex(up_ind)
+        else:
+            self.comboBox_afss_upcoming_mode.setEnabled(False)
+        # User enables/disables AutoStigmator
+        self.checkBox_afss_autostig_active.stateChanged.connect(self.switch_afss_mode_combobox)
+            
         # Disable some settings if Array mode is active
         if self.gm.array_mode:
             self.radioButton_useHeuristic.setEnabled(False)
             self.radioButton_useTrackingOnly.setEnabled(False)
             self.radioButton_useMAPFoSt.setEnabled(False)
+            self.radioButton_useAFSS.setEnabled(False)
             self.comboBox_trackingMode.setEnabled(False)
             self.spinBox_interval.setEnabled(False)
             # make autostig interval work on grids instead of slices
             self.label_autostig_delay_1.setText('Autostig interval (grids) ')
+
+    def switch_afss_mode_combobox(self, state):
+        if state == Qt.Checked:
+            if self.autofocus.acquisition_running:
+                self.comboBox_afss_mode.setEnabled(False)
+            else:
+                self.comboBox_afss_mode.setEnabled(True)
+            if self.autofocus.afss_active:
+                self.comboBox_afss_mode.setCurrentIndex(self.mode_keys.index(self.autofocus.afss_mode))
+                self.comboBox_afss_upcoming_mode.setEnabled(True)
+                self.comboBox_afss_upcoming_mode.setCurrentIndex(
+                    self.mode_keys.index(self.autofocus.afss_upcoming_mode))
+        else:
+            self.comboBox_afss_mode.setEnabled(False)
+            self.comboBox_afss_upcoming_mode.setEnabled(False)
+            if not self.autofocus.acquisition_running:
+                self.comboBox_afss_mode.setCurrentIndex(self.mode_keys.index('focus'))
+            self.comboBox_afss_upcoming_mode.setCurrentIndex(self.mode_keys.index('focus'))
 
     def group_box_update(self):
         mapfost_enabled = False
@@ -106,21 +169,31 @@ class AutofocusSettingsDlg(QDialog):
             sem_af_enabled = True
             heuristic_enabled = False
             diffs_enabled = True
+            afss_enabled = False
         elif self.radioButton_useHeuristic.isChecked():
             sem_af_enabled = False
             heuristic_enabled = True
             diffs_enabled = True
+            afss_enabled = False
         elif self.radioButton_useTrackingOnly.isChecked():
             sem_af_enabled = False
             heuristic_enabled = False
             diffs_enabled = False
+            afss_enabled = False
         elif self.radioButton_useMAPFoSt.isChecked():
             sem_af_enabled = True  # mapfost uses intervall and pixel size value.
             heuristic_enabled = False
             diffs_enabled = True
             mapfost_enabled = True  # TODO: add mapfost parameter group
+            afss_enabled = False
+        elif self.radioButton_useAFSS.isChecked():
+            sem_af_enabled = False
+            heuristic_enabled = False
+            diffs_enabled = True
+            afss_enabled = True
         self.groupBox_SEM_af.setEnabled(sem_af_enabled)
         self.groupBox_heuristic_af.setEnabled(heuristic_enabled)
+        self.groupBox_AFSS_af.setEnabled(afss_enabled)
         self.doubleSpinBox_maxWDDiff.setEnabled(diffs_enabled)
         self.doubleSpinBox_maxStigXDiff.setEnabled(diffs_enabled)
         self.doubleSpinBox_maxStigYDiff.setEnabled(diffs_enabled)
@@ -164,6 +237,8 @@ class AutofocusSettingsDlg(QDialog):
             self.autofocus.method = 2
         elif self.radioButton_useMAPFoSt.isChecked():
             self.autofocus.method = 3
+        elif self.radioButton_useAFSS.isChecked():
+            self.autofocus.method = 4
 
         success, tile_list = utils.validate_tile_list(
             self.lineEdit_refTiles.text())
@@ -185,6 +260,28 @@ class AutofocusSettingsDlg(QDialog):
         self.autofocus.wd_delta = self.doubleSpinBox_wdDiff.value() / 1000000
         self.autofocus.stig_x_delta = self.doubleSpinBox_stigXDiff.value()
         self.autofocus.stig_y_delta = self.doubleSpinBox_stigYDiff.value()
+
+        # AFSS
+        self.autofocus.interval = max(self.spinBox_afss_interval.value(), self.spinBox_afss_rounds.value())
+        self.autofocus.afss_wd_delta = self.doubleSpinBox_afss_wdDiff.value() / 1000000
+        self.autofocus.afss_stig_x_delta = self.doubleSpinBox_afss_stigXDiff.value()
+        self.autofocus.afss_stig_y_delta = self.doubleSpinBox_afss_stigYDiff.value()
+        self.autofocus.afss_rounds = self.spinBox_afss_rounds.value()
+        self.autofocus.afss_offset = self.spinBox_afss_offset.value()
+        self.autofocus.afss_consensus_mode = self.comboBox_afss_consensus_mode.currentIndex()
+        self.autofocus.afss_drift_corrected = self.checkBox_afss_drift_corrected.isChecked()
+        self.autofocus.afss_autostig_active = self.checkBox_afss_autostig_active.isChecked()
+        self.autofocus.afss_max_fails = self.spinBox_afss_fails.value()
+        self.autofocus.afss_rmse_limit = self.doubleSpinBox_afss_rmse_limit.value()
+        self.autofocus.afss_background_mode = self.checkBox_afss_background_mode.isChecked()
+        self.autofocus.afss_mode = self.mode_keys[self.comboBox_afss_mode.currentIndex()]
+        self.autofocus.afss_upcoming_mode = self.mode_keys[self.comboBox_afss_upcoming_mode.currentIndex()]
+        self.img_inspector.afss_drift_corr = self.checkBox_afss_drift_corrected.isChecked()
+        if not self.autofocus.acquisition_running:
+            self.autofocus.afss_upcoming_mode = self.autofocus.next_afss_mode()
+            self.comboBox_afss_upcoming_mode = self.autofocus.afss_upcoming_mode
+        else:
+            self.comboBox_afss_upcoming_mode = self.autofocus.afss_upcoming_mode
 
         self.autofocus.heuristic_calibration = [
             self.doubleSpinBox_focusCalib.value(),

--- a/src/image_io.py
+++ b/src/image_io.py
@@ -1,11 +1,8 @@
 import imageio.v3 as iio
 import numpy as np
 import os
-# import tifffile
-# from tifffile import TiffWriter, PHOTOMETRIC
-
 import tifffile
-from tifffile import TiffWriter
+from tifffile import TiffWriter, PHOTOMETRIC
 
 from constants import VERSION
 from utils import resize_image, int2float_image, float2int_image, norm_image_quantiles, validate_output_path
@@ -19,33 +16,6 @@ CONVERSIONS = {'nm': 1e-3, 'nanometer': 1e-3,
                'cm': 1e4, 'centimeter': 1e4,
                'm': 1e6, 'meter': 1e6}
 
-### FALLBACK
-# Compatibility shim for photometric values across tifffile versions (and Python 3.7)
-try:
-    # Newer tifffile (Python 3.12+ world)
-    from tifffile import PHOTOMETRIC as _PH
-    PH_RGB = getattr(_PH, 'RGB', 'rgb')
-    PH_MINISBLACK = getattr(_PH, 'MINISBLACK', 'minisblack')
-except Exception:
-    # Older tifffile (common on Python 3.7)
-    try:
-        from tifffile import TIFF as _TIFF  # older API
-        PH_RGB = getattr(_TIFF.PHOTOMETRIC, 'RGB', 'rgb')
-        PH_MINISBLACK = getattr(_TIFF.PHOTOMETRIC, 'MINISBLACK', 'minisblack')
-    except Exception:
-        # Last-resort: strings (valid for TiffWriter.write)
-        PH_RGB = 'rgb'
-        PH_MINISBLACK = 'minisblack'
-
-
-try:
-    import imageio.v3 as iio
-    _has_improps = hasattr(iio, 'improps')
-except Exception:
-    import imageio as iio
-    _has_improps = False
-
-### EOF FALLBACK
 
 def imread(path, level=None, source_pixel_size_um=None, target_pixel_size_um=None, channeli=None, render=True):
     image = None
@@ -261,38 +231,17 @@ def imread_metadata(path):
                             if yres is not None and yres != 0:
                                 pixel_size.append((1 / yres, units))
     else:
-        # try:
-        #     properties = iio.improps(path)
-        #     size = properties.shape[1], properties.shape[0]
-        #     sizes = [size]
-        #     resolution = properties.spacing
-        #     if resolution:
-        #         metadata = iio.immeta(path)
-        #         units = metadata.get('unit')
-        #         pixel_size = [(1 / res, units) for res in resolution]
-        # except Exception as e:
-        #     raise TypeError(f'Error reading image {path}\n{e}')
-
         try:
-            # imageio.v3 path (newer Python, if available)
-            if _has_improps:
-                props = iio.improps(path)
-                size = props.shape[1], props.shape[0]
-                sizes = [size]
-                resolution = getattr(props, "spacing", None)
-                if resolution:
-                    metadata = iio.immeta(path)
-                    units = metadata.get("unit")
-                    pixel_size = [(1 / res, units) for res in resolution]
-            else:
-                # Fallback for Python 3.7: just read with imageio
-                img = iio.imread(path)
-                size = img.shape[1], img.shape[0]
-                sizes = [size]
-                # No resolution metadata available here
-                resolution = None
+            properties = iio.improps(path)
+            size = properties.shape[1], properties.shape[0]
+            sizes = [size]
+            resolution = properties.spacing
+            if resolution:
+                metadata = iio.immeta(path)
+                units = metadata.get('unit')
+                pixel_size = [(1 / res, units) for res in resolution]
         except Exception as e:
-            raise TypeError(f"Error reading image {path}\n{e}")
+            raise TypeError(f'Error reading image {path}\n{e}')
 
     all_metadata['dimension_order'] = dimension_order
     all_metadata['size'] = size
@@ -382,20 +331,12 @@ def imwrite(path, data, metadata=None, tile_size=None, compression=None,
     size = np.flip(data.shape[:2])
 
     if is_tiff:
-        # if data.ndim <= 3 and data.shape[-1] in (3, 4):
-        #     photometric = PHOTOMETRIC.RGB
-        #     move_channel = False
-        # else:
-        #     photometric = PHOTOMETRIC.MINISBLACK
-        #     # move channel axis to front
-        #     move_channel = (data.ndim >= 3 and data.shape[-1] < data.shape[0])
-
         if data.ndim <= 3 and data.shape[-1] in (3, 4):
-            photometric = PH_RGB
+            photometric = PHOTOMETRIC.RGB
             move_channel = False
         else:
-            photometric = PH_MINISBLACK
-            # move channel axis to front if last axis is the channel
+            photometric = PHOTOMETRIC.MINISBLACK
+            # move channel axis to front
             move_channel = (data.ndim >= 3 and data.shape[-1] < data.shape[0])
 
         if metadata is not None:

--- a/src/image_io.py
+++ b/src/image_io.py
@@ -1,8 +1,11 @@
 import imageio.v3 as iio
 import numpy as np
 import os
+# import tifffile
+# from tifffile import TiffWriter, PHOTOMETRIC
+
 import tifffile
-from tifffile import TiffWriter, PHOTOMETRIC
+from tifffile import TiffWriter
 
 from constants import VERSION
 from utils import resize_image, int2float_image, float2int_image, norm_image_quantiles, validate_output_path
@@ -16,6 +19,33 @@ CONVERSIONS = {'nm': 1e-3, 'nanometer': 1e-3,
                'cm': 1e4, 'centimeter': 1e4,
                'm': 1e6, 'meter': 1e6}
 
+### FALLBACK
+# Compatibility shim for photometric values across tifffile versions (and Python 3.7)
+try:
+    # Newer tifffile (Python 3.12+ world)
+    from tifffile import PHOTOMETRIC as _PH
+    PH_RGB = getattr(_PH, 'RGB', 'rgb')
+    PH_MINISBLACK = getattr(_PH, 'MINISBLACK', 'minisblack')
+except Exception:
+    # Older tifffile (common on Python 3.7)
+    try:
+        from tifffile import TIFF as _TIFF  # older API
+        PH_RGB = getattr(_TIFF.PHOTOMETRIC, 'RGB', 'rgb')
+        PH_MINISBLACK = getattr(_TIFF.PHOTOMETRIC, 'MINISBLACK', 'minisblack')
+    except Exception:
+        # Last-resort: strings (valid for TiffWriter.write)
+        PH_RGB = 'rgb'
+        PH_MINISBLACK = 'minisblack'
+
+
+try:
+    import imageio.v3 as iio
+    _has_improps = hasattr(iio, 'improps')
+except Exception:
+    import imageio as iio
+    _has_improps = False
+
+### EOF FALLBACK
 
 def imread(path, level=None, source_pixel_size_um=None, target_pixel_size_um=None, channeli=None, render=True):
     image = None
@@ -231,17 +261,38 @@ def imread_metadata(path):
                             if yres is not None and yres != 0:
                                 pixel_size.append((1 / yres, units))
     else:
+        # try:
+        #     properties = iio.improps(path)
+        #     size = properties.shape[1], properties.shape[0]
+        #     sizes = [size]
+        #     resolution = properties.spacing
+        #     if resolution:
+        #         metadata = iio.immeta(path)
+        #         units = metadata.get('unit')
+        #         pixel_size = [(1 / res, units) for res in resolution]
+        # except Exception as e:
+        #     raise TypeError(f'Error reading image {path}\n{e}')
+
         try:
-            properties = iio.improps(path)
-            size = properties.shape[1], properties.shape[0]
-            sizes = [size]
-            resolution = properties.spacing
-            if resolution:
-                metadata = iio.immeta(path)
-                units = metadata.get('unit')
-                pixel_size = [(1 / res, units) for res in resolution]
+            # imageio.v3 path (newer Python, if available)
+            if _has_improps:
+                props = iio.improps(path)
+                size = props.shape[1], props.shape[0]
+                sizes = [size]
+                resolution = getattr(props, "spacing", None)
+                if resolution:
+                    metadata = iio.immeta(path)
+                    units = metadata.get("unit")
+                    pixel_size = [(1 / res, units) for res in resolution]
+            else:
+                # Fallback for Python 3.7: just read with imageio
+                img = iio.imread(path)
+                size = img.shape[1], img.shape[0]
+                sizes = [size]
+                # No resolution metadata available here
+                resolution = None
         except Exception as e:
-            raise TypeError(f'Error reading image {path}\n{e}')
+            raise TypeError(f"Error reading image {path}\n{e}")
 
     all_metadata['dimension_order'] = dimension_order
     all_metadata['size'] = size
@@ -331,12 +382,20 @@ def imwrite(path, data, metadata=None, tile_size=None, compression=None,
     size = np.flip(data.shape[:2])
 
     if is_tiff:
+        # if data.ndim <= 3 and data.shape[-1] in (3, 4):
+        #     photometric = PHOTOMETRIC.RGB
+        #     move_channel = False
+        # else:
+        #     photometric = PHOTOMETRIC.MINISBLACK
+        #     # move channel axis to front
+        #     move_channel = (data.ndim >= 3 and data.shape[-1] < data.shape[0])
+
         if data.ndim <= 3 and data.shape[-1] in (3, 4):
-            photometric = PHOTOMETRIC.RGB
+            photometric = PH_RGB
             move_channel = False
         else:
-            photometric = PHOTOMETRIC.MINISBLACK
-            # move channel axis to front
+            photometric = PH_MINISBLACK
+            # move channel axis to front if last axis is the channel
             move_channel = (data.ndim >= 3 and data.shape[-1] < data.shape[0])
 
         if metadata is not None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -880,7 +880,7 @@ def register_image_collection(ic: np.ndarray) -> np.ndarray:
 
 
 def compute_shifts_cv2(files: List[str]):
-    # Copmutes translation vectors between AFSS images
+    # Computes translation vectors between AFSS images
     def compute_shift(image1, image2):
         def negate_tuple(tup):
             return tuple(-x for x in tup)
@@ -1000,7 +1000,7 @@ def get_weights(input_array: list, smallest_weight: float) -> list:
     return list(weights + fcts)
 
 
-def afss_fit_linear(x_vals, y_vals, min_slope):
+def afss_fit_linear(x_vals, y_vals, min_slope) -> Tuple[Tuple, bool]:
     """
     Perform linear fit on x AFSS series sharpness values, return max y-value,
     corresponding x-value, and fit RMSE of fitted line over x-range if
@@ -1012,7 +1012,7 @@ def afss_fit_linear(x_vals, y_vals, min_slope):
         min_slope: Float, minimum absolute slope for a valid fit.
 
     Returns:
-        Tuple: (max_y, x_at_max_y, fit_rmse, plot x-range, plot y-range, fit outcome)
+        Tuple: ((max_y, x_at_max_y, fit_rmse, plot x-range, plot y-range), fit outcome)
             - max_y: Max y-value of fitted line (at min or max x) if successful, else None.
             - x_at_max_y: x-value where max y occurs if successful, else None.
             - fit_rmse: RMSE of the fit if successful, else -1.
@@ -1065,11 +1065,11 @@ def afss_fit_linear(x_vals, y_vals, min_slope):
     # Smooth line over x range for plotting
     x_fit = np.linspace(x_min, x_max, 100)
     y_fit = m * x_fit + c
+    res = x_at_max_y, max_y, fit_rmse, x_fit, y_fit
+    return res, is_successful
 
-    return x_at_max_y, max_y, fit_rmse, x_fit, y_fit, is_successful
 
-
-def afss_fit_poly(x_vals: np.ndarray, y_vals: np.ndarray) -> tuple:
+def afss_fit_poly(x_vals: np.ndarray, y_vals: np.ndarray) -> Tuple[Tuple, bool]:
     """
     Fit AFSS series data with a polynomial and compute optimal point.
 
@@ -1077,7 +1077,7 @@ def afss_fit_poly(x_vals: np.ndarray, y_vals: np.ndarray) -> tuple:
         x_vals: Input x values
         y_vals: Input y values
     Returns:
-        tuple: (x_opt, y_opt, RMSE, plot x-range, plot y-range, fit outcome)
+        tuple: (x_opt, y_opt, RMSE, plot x-range, plot y-range), fit outcome
     """
 
     # Fit sharpness values with second-order polynom
@@ -1101,6 +1101,7 @@ def afss_fit_poly(x_vals: np.ndarray, y_vals: np.ndarray) -> tuple:
         x_opt = None
         y_opt = None
 
-    return x_opt, y_opt, fit_rmse, x_fit, fit(x_fit), is_successful
+    res = x_opt, y_opt, fit_rmse, x_fit, fit(x_fit)
+    return res, is_successful
 
 # -------------- EOF AFSS computation utils --------------

--- a/src/utils.py
+++ b/src/utils.py
@@ -801,6 +801,17 @@ def match_template(img: np.ndarray, templ: np.ndarray, thresh_match: float) -> n
 
 
 # -------------- AFSS computation utils --------------
+def parse_tile_key(tile_key: str) -> Tuple[int, int]:
+    """Parses tile_key into g and t, ensuring exactly two components."""
+    parts = tile_key.split('.')
+
+    # Check if there are exactly two components
+    if len(parts) != 2:
+        raise ValueError(f"Invalid tile_key format: {tile_key}. Expected format 'g.t' with exactly two parts.")
+
+    g, t = map(int, parts)
+    return g, t
+
 
 def grad_img(data: np.ndarray) -> np.ndarray:
     scale = 1

--- a/src/utils.py
+++ b/src/utils.py
@@ -815,6 +815,28 @@ def grad_img(data: np.ndarray) -> np.ndarray:
     return cv2.magnitude(grad_x, grad_y)
 
 
+def inspect_masked_img(img: np.ndarray, mask: np.ndarray) -> Tuple[float, float, float]:
+    """Calculates image statistics on centered circular region of the image."""
+
+    # Default vals
+    ma_mean, ma_stddev, ma_sharp = 0, 0, 0
+
+    if not isinstance(img, np.ndarray):
+        return ma_mean, ma_stddev, ma_sharp
+
+    # Apply circular binary mask on original image
+    img = np.ma.array(img, mask=mask)
+
+    # Apply circular binary mask on gradient image
+    img_grad = np.ma.array(grad_img(img), mask=mask)
+
+    # Calculate mean, stddev, sharpness on center circular region of image
+    # ma_mean = img.mean()  not used
+    ma_stddev = img.std()
+    ma_sharp = img_grad.mean()
+    return ma_mean, ma_stddev, ma_sharp
+
+
 def imread_cv2(path: str) -> np.ndarray:
     return cv2.imread(path, cv2.IMREAD_GRAYSCALE).astype(np.float32)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -801,14 +801,13 @@ def match_template(img: np.ndarray, templ: np.ndarray, thresh_match: float) -> n
 
 
 # -------------- AFSS computation utils --------------
+
 def parse_tile_key(tile_key: str) -> Tuple[int, int]:
     """Parses tile_key into g and t, ensuring exactly two components."""
     parts = tile_key.split('.')
-
     # Check if there are exactly two components
     if len(parts) != 2:
         raise ValueError(f"Invalid tile_key format: {tile_key}. Expected format 'g.t' with exactly two parts.")
-
     g, t = map(int, parts)
     return g, t
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,6 +17,9 @@ import logging
 import threading
 import cv2
 import numpy as np
+import glob
+from os.path import basename
+from typing import Tuple, List
 
 from configparser import ConfigParser
 from time import sleep
@@ -24,13 +27,21 @@ from queue import Queue
 from logging import StreamHandler
 from logging.handlers import RotatingFileHandler
 
+from skimage import draw
 from skimage.transform import ProjectiveTransform
 from skimage.measure import ransac
+from skimage.io import imread, imsave, ImageCollection
+from skimage.util import crop, img_as_ubyte
+from skimage.registration import phase_cross_correlation
+from skimage.transform import rescale, ProjectiveTransform
+
 from serial.tools import list_ports
 from qtpy.QtCore import QObject, Signal, QSize
 from qtpy.QtGui import QIcon, QPixmap, QImage, QTransform
 from scipy.ndimage import maximum_filter
-
+from scipy.ndimage import interpolation
+from shapely.geometry import Polygon, Point
+from serial.tools import list_ports
 from constants import *
 
 
@@ -786,3 +797,288 @@ def match_template(img: np.ndarray, templ: np.ndarray, thresh_match: float) -> n
         # store coordinate of this object
         locs[ix] = np.mean(match[sl] == (ix + 1)) + np.array([sl[0].start, sl[1].start])
     return locs.astype(int)
+
+
+
+# -------------- AFSS computation utils --------------
+
+def grad_img(data: np.ndarray) -> np.ndarray:
+    scale = 1
+    delta = 0
+    ddepth = cv2.CV_32F
+
+    # Compute gradients along x and y axes
+    grad_x = cv2.Scharr(data, ddepth, 1, 0, scale=scale, delta=delta, borderType=cv2.BORDER_DEFAULT)
+    grad_y = cv2.Scharr(data, ddepth, 0, 1, scale=scale, delta=delta, borderType=cv2.BORDER_DEFAULT)
+
+    # Return the magnitude of the gradient (combined gradient in both x and y directions)
+    return cv2.magnitude(grad_x, grad_y)
+
+
+def imread_cv2(path: str) -> np.ndarray:
+    return cv2.imread(path, cv2.IMREAD_GRAYSCALE).astype(np.float32)
+
+def create_mask(tile_size):
+    width, height = tile_size
+    center = (int(height / 2), int(width / 2))
+    radius = int(height / 3)
+    rr, cc = draw.disk(center, radius)
+    mask = np.ones((height, width), dtype=bool)
+    mask[rr, cc] = False
+    return mask
+
+
+def save_mask(mask, filename):
+    try:
+        imsave(filename, img_as_ubyte(mask))
+    except Exception as e:
+        log_exception(f"Failed to save {filename}: {e}")
+        raise
+
+
+def load_masks(path):
+    masks = {}
+    for fn in glob.glob(path + '\\mask_*.tif'):
+        key = str.split(basename(fn), '.')[0]
+        masks[key] = imread(fn)
+    return masks
+
+
+def load_image_collection(filenames: list) -> np.ndarray:
+    return ImageCollection(filenames, conserve_memory=True).concatenate()
+
+
+def register_image_collection(ic: np.ndarray) -> np.ndarray:
+    shifts = []
+    for i, img in enumerate(ic[:-1]):
+        # Do not use (upsample_factor > 1) as it spoils the image information!
+        shifts.append(phase_cross_correlation(ic[i], ic[i+1], upsample_factor=1))
+    cumulative_shifts = np.cumsum(shifts, axis=0)
+    return cumulative_shifts
+
+
+def compute_shifts_cv2(files: List[str]):
+    # Copmutes translation vectors between AFSS images
+    def compute_shift(image1, image2):
+        def negate_tuple(tup):
+            return tuple(-x for x in tup)
+
+        def fix_vec(vec: tuple) -> np.ndarray:
+            vec = np.round(vec[::-1])
+            vec = np.asarray(negate_tuple(vec))
+            vec = np.reshape(vec, [1, 2])
+            return vec
+
+        shift_vec, error = cv2.phaseCorrelate(image1, image2)
+        return fix_vec(shift_vec), error
+
+    shift = 0.0
+    for i in range(1, len(files)):
+        ref = imread_cv2(files[i - 1])
+        cur = imread_cv2(files[i])
+        shift, err = compute_shift(ref, cur)
+    return shift
+
+
+def crop_image_collection(image_collection: np.ndarray, cumm_shifts: np.ndarray) -> np.ndarray:
+    sX, sY = np.asarray(cumm_shifts)[:, 1], np.asarray(cumm_shifts)[:, 0]
+    sx = np.array(np.round([abs(np.max(sX)), abs(np.min(sX))]), dtype=int)
+    sy = np.array(np.round([abs(np.max(sY)), abs(np.min(sY))]), dtype=int)
+    crop_vals = ([0, 0], sy, sx)
+    return crop(image_collection, crop_vals)
+
+
+def shift_collection(ic: np.ndarray, cumm_shifts: np.ndarray) -> np.ndarray:
+    for i, im in enumerate(ic[1:]):
+        ic[i+1] = interpolation.shift(im, cumm_shifts[i])
+    return ic
+
+
+def get_collection_mask(coll_xy_shape: Tuple[int, int]) -> np.ndarray:
+    h, w = coll_xy_shape
+    y, x = np.ogrid[:h, :w]
+    center_y, center_x = h // 2, w // 2
+    radius = h // 3
+    mask = (y - center_y)**2 + (x - center_x)**2 > radius**2
+    return mask
+
+
+def validate_img_collection(img_coll) -> bool:
+    # Verifies tile-image collection after registration and crop operations
+    coll_valid = True
+
+    # Check if the input image is valid (non-empty and non-None)
+    if any(image is None or image.size == 0 for image in img_coll):
+        coll_valid = False
+    return coll_valid
+
+
+def store_reg_coll(img_coll, filenames, prefix):
+    # Save sharpness plots to project stats folder
+    scale_down = True
+    scale_fct = 0.1  # Downscaling the registered series saves disk space
+
+    for j, fn in enumerate(filenames):
+        reg_img_path = os.path.join(prefix, os.path.basename(fn))
+        if scale_down:
+            im_out = rescale(img_coll[j], scale_fct, anti_aliasing=False)
+        else:
+            im_out = img_coll[j]
+        imsave(reg_img_path, im_out)
+    return
+
+
+def get_collection_sharpness(ic: np.ndarray, metric: str) -> list:
+    """
+    Computes sharpness of series of images to later estimate best focus/stig from AFSS series
+    Args:
+        ic: image collection of autofocus tile AFSS series
+        metric: 'contrast' computes sharpness as standard deviation of image brightness 
+                'edges' computes sharpness as a mean value of image convolved with Sobel operator
+    """
+    sh_arr = []
+
+    x, y = np.shape(ic[0])
+    mask = get_collection_mask((x, y))
+
+    for img in ic:
+        if metric == 'contrast':
+            sh_arr.append(np.std(img))
+        elif metric == 'edges':
+            masked_grad_img = np.ma.array(grad_img(img), mask=mask, dtype=np.float32)
+            sh_arr.append(np.mean(masked_grad_img))
+    return sh_arr
+
+
+def filter_outliers(data: np.ndarray, m=2., epsilon=1e-8) -> np.ndarray:
+    d = np.abs(data - np.median(data))
+    mdev = np.median(d) + epsilon  # Add epsilon to prevent division by very small values
+    s = d / mdev
+    return data[s < m]
+
+
+def rmse(predictions: np.ndarray, targets: np.ndarray) -> float:
+    """" Computes root mean squared error of fit values (predictions) to measured values (target)"""
+    return np.sqrt(np.mean((predictions-targets)**2))
+
+
+def get_weights(input_array: list, smallest_weight: float) -> list:
+    """
+    Linear weighing is applied to the input_array (list of diffs from afss_series optima)
+    Values are recalibrated to the range [smallest_weight:1], where 1 is given to the
+    lowest value from input array
+    """
+    def norm_data(arr: list) -> np.ndarray:
+        arr = np.asarray(arr)
+        arr *= -1   # inversion as highest weight (w=1.0) will be given to the lowest RMSE error
+        arr -= min(arr)
+        return arr/max(arr)
+    weights = norm_data(input_array)
+    fcts = smallest_weight * (1 - weights)
+    return list(weights + fcts)
+
+
+def afss_fit_linear(x_vals, y_vals, min_slope):
+    """
+    Perform linear fit on x AFSS series sharpness values, return max y-value,
+    corresponding x-value, and fit RMSE of fitted line over x-range if
+    fit_rmse < limit and |slope| >= min_slope.
+
+    Args:
+        x_vals: NumPy array of x values.
+        y_vals: NumPy array of y values (must be same length as x_vals).
+        min_slope: Float, minimum absolute slope for a valid fit.
+
+    Returns:
+        Tuple: (max_y, x_at_max_y, fit_rmse, plot x-range, plot y-range, fit outcome)
+            - max_y: Max y-value of fitted line (at min or max x) if successful, else None.
+            - x_at_max_y: x-value where max y occurs if successful, else None.
+            - fit_rmse: RMSE of the fit if successful, else -1.
+
+    Raises:
+        ValueError: If arrays are empty, have fewer than 2 points, or have unequal lengths.
+    """
+    # Input validation
+    if len(x_vals) == 0 or len(y_vals) == 0:
+        raise ValueError("Input arrays cannot be empty")
+    if len(x_vals) < 2:
+        raise ValueError("At least two points are required for linear fit")
+    if len(x_vals) != len(y_vals):
+        raise ValueError("x_vals and y_vals must have equal length")
+
+    # Ensure NumPy arrays
+    x = np.asarray(x_vals)
+    y = np.asarray(y_vals)
+
+    # Compute x-range for plotting and max y calculation
+    x_min, x_max = np.min(x), np.max(x)
+
+    # Perform linear fit (y = mx + c)
+    coefficients = np.polyfit(x, y, 1)  # Degree 1 for linear
+    m, c = coefficients  # Slope and intercept
+
+    # Calculate fitted y-values
+    y_fitted = m * x + c
+
+    # Calculate RMSE
+    mse = np.mean((y - y_fitted) ** 2)
+    fit_rmse = np.sqrt(mse)
+
+    # Determine if fit is successful
+    is_successful = abs(m) >= min_slope
+
+    # Compute return values
+    if is_successful:
+        # Determine fit y-val at x-range border
+        if m > 0:
+            max_y = m * x_max + c
+            x_at_max_y = x_max
+        else:
+            max_y = m * x_min + c
+            x_at_max_y = x_min
+    else:
+        max_y = None
+        x_at_max_y = None
+
+    # Smooth line over x range for plotting
+    x_fit = np.linspace(x_min, x_max, 100)
+    y_fit = m * x_fit + c
+
+    return x_at_max_y, max_y, fit_rmse, x_fit, y_fit, is_successful
+
+
+def afss_fit_poly(x_vals: np.ndarray, y_vals: np.ndarray) -> tuple:
+    """
+    Fit AFSS series data with a polynomial and compute optimal point.
+
+    Args:
+        x_vals: Input x values
+        y_vals: Input y values
+    Returns:
+        tuple: (x_opt, y_opt, RMSE, plot x-range, plot y-range, fit outcome)
+    """
+
+    # Fit sharpness values with second-order polynom
+    x_min, x_max = min(x_vals), max(x_vals)
+    x_fit = np.linspace(x_min, x_max, num=101, endpoint=True)
+    cfs = np.polyfit(x_vals, y_vals, deg=2)
+    fit = np.poly1d(cfs)
+    fit_rmse = rmse(fit(x_vals), y_vals)
+
+    # Verify sharpness values follow expected (negative) quadratic behavior
+    is_successful = cfs[0] < 0
+    if is_successful:
+        x_opt = -cfs[1] / (2 * cfs[0])
+        # Limit the resulting optimum to the range of WD/Stig deviation
+        if x_opt < x_min:
+            x_opt = x_min
+        elif x_opt > x_max:
+            x_opt = x_max
+        y_opt = fit(x_opt)
+    else:
+        x_opt = None
+        y_opt = None
+
+    return x_opt, y_opt, fit_rmse, x_fit, fit(x_fit), is_successful
+
+# -------------- EOF AFSS computation utils --------------


### PR DESCRIPTION
This pull request introduces **Automated Focus/Stigmator Series** autofunction into official dev branch. Tested in simulation mode and in 'production' at ZEISS Gemini SEM (+Focal Charge Compensation) and Merlin SEM systems, both equipped with Gatan 3View. These set-ups are running under Win7 OS and Python 3.7 environment. Due to this limitation and conflicts (tifffile library) a fallback code had to be used temporarily in _image_io.py_ and removed just before the pull request. 

Main functionality was implemented in 2023 and since then it has been extensively used and optimized at Friedrich lab for SBFI-SEM acquisitions of very sensitive Zebrafish brain samples embedded in Epoxy resin. Typically, volumes up to 500 cubic micrometers with voxel size of (10x10x25) nm were acquired. AFSS was not tested on different tissues nor different SEM/microtome systems. 

A short user manual can be found in docs.

Tomas Gancarcik
Application Specialist Electron Microscopy
Friedrich Miescher Institute for Biomedical Research
Basel